### PR TITLE
Add fmt and misc to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Provides a way to format Janet code strings and files.
 (import spork/fmt)
 
 (fmt/format "(def     a\n 3 )")  => @"(def a\n  3)\n"
-
 ```
 
 ### Files
@@ -65,7 +64,7 @@ Launch a networked REPL server on one machine and connect to it from another mac
 
 ## RPC Protocol
 
-A simple remote procedure call tool for Janet. 
+A simple remote procedure call tool for Janet.
 
 ### Server
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 Various Janet utility modules.
 
+
+## Formatting
+
+Provides a way to format Janet code strings and files.
+
+### Strings
+
+```
+(import spork/fmt)
+
+(fmt/format "(def     a\n 3 )")  => @"(def a\n  3)\n"
+
+```
+
+### Files
+
+```
+(import spork/fmt)
+
+(fmt/format-file "main.janet")
+```
+
 ## Message Protocol
 
 Provide a symmetric way to send and receive seqential messages over a networked stream.

--- a/README.md
+++ b/README.md
@@ -91,3 +91,16 @@ A simple remote procedure call tool for Janet.
 # Close the underlying connection
 (:close c)
 ```
+
+## Misc
+
+### Dedent
+
+Remove indentation after concatenating the arguments.
+
+```
+(misc/dedent ```
+      ho
+        hoho
+          hohoho
+```))))) => "ho\n  hoho\n    hohoho"

--- a/spork/msg.janet
+++ b/spork/msg.janet
@@ -31,7 +31,7 @@
 
 (defn make-send
   "Create a function that when called with a msgs sends that msg.
-  Pass an option pack function that will convert a message to a string."
+  Provide an optional pack function that will convert a message to a string."
   [stream &opt pack]
   (def buf @"")
   (default pack string)


### PR DESCRIPTION
I put it at the top, so when we direct someone to the correct Janet format, it is the first thing she sees in the README.