### PR TITLE
Tweak some ranges in escapedchar2

### DIFF
--- a/spork/regex.janet
+++ b/spork/regex.janet
@@ -95,8 +95,8 @@
       # Other single characters
       :escapedchar2 (+ (/ `\s` (set "\n\t\r\v\f "))
                        (/ `\d` (range "09"))
-                       (/ `\a` (range "AZaz"))
-                       (/ `\w` (range "AZaz09"))
+                       (/ `\a` (range "AZ" "az"))
+                       (/ `\w` (range "AZ" "az" "09"))
                        (/ `\S` (range "\0\x08" "\x0e\x1f" "\x21\xff"))
                        (/ `\D` (range "\0\x2f" "\x3a\xff"))
                        (/ `\A` (range "\0\x40" "\x5b\x60" "\x7b\xff"))

--- a/test/suite4.janet
+++ b/test/suite4.janet
@@ -13,4 +13,7 @@
                (regex/match `(?:(abc)){4}` "abcabcabcabc"))
         "match 6")
 
+(assert (regex/match `\a+` `Xy`) "match 7")
+(assert (regex/match `\w+` `Xy0`) "match 8")
+
 (end-suite)


### PR DESCRIPTION
An attempt to get `\a` and `\w` working.

Also some related tests.

