### PR TITLE
Working versions of misc/timeit and misc/set*

### DIFF
--- a/test/suite1.janet
+++ b/test/suite1.janet
@@ -2,5 +2,49 @@
 (import ../spork/misc)
 
 (start-suite 1)
+
+#misc/dedent
 (assert (= (misc/dedent "  a\n    b\n   c\n     d") "a\n  b\n c\n   d") "dedent")
+
+#misc/timeit
+(defmacro- capture-stdout
+  [form]
+  (with-syms [buf res]
+    ~(do
+      (def ,buf (buffer/new 1024))
+      (with-dyns [:out ,buf]
+        (def ,res ,form)
+        [,res (string ,buf)]))))
+
+(do
+  (def [result output]
+    (capture-stdout
+      (misc/timeit (loop [i :range [1 100000]] i) "foo:")))
+  (assert (nil? result))
+  (def m (peg/match '(* "foo: " (<- (some :S)) " seconds\n" -1) output))
+  (assert (truthy? m) "timeit -- invalid output")
+  (assert (scan-number (in m 0)) "timeit -- invalid number of seconds"))
+
+(do
+  (def [result output]
+    (capture-stdout
+      (misc/timeit "someresult")))
+  (assert (= result "someresult") "timeit2 -- invalid return")
+  (def m (peg/match '(* "Elapsed time: " (<- (some :S)) " seconds\n" -1) output))
+  (assert (truthy? m) "timeit2 -- invalid output")
+  (assert (scan-number (in m 0)) "timeit2 -- invalid number of seconds"))
+
+#misc/set*
+(do
+  (var x 2)
+  (var y 3)
+  (misc/set* [x y] [y (+ x y)])
+  (print x " " y)
+  (assert (and (= x 3) (= y 5)) "set* 1"))
+
+(do
+  (def x @[2 3])
+  (misc/set* [[x 0] [x 1]] [(in x 1) (+ (in x 0) (in x 1))])
+  (assert (deep= x @[3 5])))
+
 (end-suite)


### PR DESCRIPTION
This commit adds two functions to spork/misc -- timeit, a macro for timing pieces of code using os/clock, and set*, a macro for parallel set.  Both of these were discussed with @bakpakin on gitter today so I didn't create an issue before submitting the PR.  Caveat -- I'm not a macro expert so, regardless of the fact that I did provide some working tests, you should feel free to reject based on style or any concerns you have.  Just let me know what I would need to do to clean it up.