### PR TITLE
Tweak repetition comment

### DIFF
--- a/spork/regex.janet
+++ b/spork/regex.janet
@@ -10,7 +10,7 @@
 ###   - single bytes
 ###   - escape characters
 ###   - +, *, ?, .
-###   - Repetitions, e.g. abc{1}, abc{1,3}. Repetitions are eagerly evaluated.
+###   - Repetitions, e.g. a{1}, a{1,3}. Repetitions are eagerly evaluated.
 ###   - Ranges, e.g. [A-Za-z]
 ###   - Character classes, inverted character classes, e.g. [abc], [^abc]
 ###   - Alteration (choice), except alteration is ordered, as in pegs - e.g a|b|c


### PR DESCRIPTION
I found the comment about repetitions in `regex.janet` to be confusing: https://github.com/janet-lang/spork/blob/6f8b5a8431dba7fa2df54e6be9eea42d9a4e97d6/spork/regex.janet#L13

I took the curly braces and number to refer to `abc` in `abc{1}`, but that does not seem to be correct:
```
repl:2:> (regex/match "ab{2}" "abab")
nil
repl:3:> (regex/match "(ab){2}" "abab")
@["ab" "ab"]
```

This PR is just a tweak so that instead of `abc{1}` or `abc{1,3}`, `a{1}` and `a{1,3}` are used instead.