### PR TITLE
Add error if there is anything after :root

### DIFF
--- a/spork/fmt.janet
+++ b/spork/fmt.janet
@@ -45,7 +45,7 @@
       :parray (/ (group (* "@(" :root (+ ")" (error "")))) ,(pnode :array))
       :barray (/ (group (* "@[" :root (+ "]" (error "")))) ,(pnode :array))
       :dict (/ (group (* "@{" :root2 (+ "}" (error "")))) ,(pnode :table))
-      :main :root}))
+      :main (* :root (+ -1 (error "")))}))
 
 (defn- make-tree
   "Turn a string of source code into a tree that will be printed"

--- a/spork/fmt.janet
+++ b/spork/fmt.janet
@@ -39,13 +39,13 @@
       :value (* :spacing (any (+ :ws :readermac)) :raw-value :spacing)
       :root (any :value)
       :root2 (any (* :value :value))
-      :ptuple (/ (group (* "(" :root (+ ")" (error "")))) ,(pnode :ptuple))
-      :btuple (/ (group (* "[" :root (+ "]" (error "")))) ,(pnode :btuple))
-      :struct (/ (group (* "{" :root2 (+ "}" (error "")))) ,(pnode :struct))
-      :parray (/ (group (* "@(" :root (+ ")" (error "")))) ,(pnode :array))
-      :barray (/ (group (* "@[" :root (+ "]" (error "")))) ,(pnode :array))
-      :dict (/ (group (* "@{" :root2 (+ "}" (error "")))) ,(pnode :table))
-      :main (* :root (+ -1 (error "")))}))
+      :ptuple (/ (group (* "(" :root (+ ")" (error)))) ,(pnode :ptuple))
+      :btuple (/ (group (* "[" :root (+ "]" (error)))) ,(pnode :btuple))
+      :struct (/ (group (* "{" :root2 (+ "}" (error)))) ,(pnode :struct))
+      :parray (/ (group (* "@(" :root (+ ")" (error)))) ,(pnode :array))
+      :barray (/ (group (* "@[" :root (+ "]" (error)))) ,(pnode :array))
+      :dict (/ (group (* "@{" :root2 (+ "}" (error)))) ,(pnode :table))
+      :main (* :root (+ -1 (error)))}))
 
 (defn- make-tree
   "Turn a string of source code into a tree that will be printed"


### PR DESCRIPTION
It fixes #14 by throwing an error if there is code after `:root` in `:main`.