### PR TITLE
Improve spacing support in fmt

### DIFF
--- a/spork/fmt.janet
+++ b/spork/fmt.janet
@@ -36,9 +36,9 @@
       :long-buffer (/ (* "@" :long-bytes) ,(pnode :buffer))
       :raw-value (+ :string :buffer :long-string :long-buffer
                     :parray :barray :ptuple :btuple :struct :dict :span)
-      :value (* :spacing (any (+ :ws :readermac)) :raw-value :spacing)
-      :root (any :value)
-      :root2 (any (* :value :value))
+      :value (* (any (+ :ws :readermac)) :raw-value :spacing)
+      :root (* :spacing (any :value))
+      :root2 (* :spacing (any (* :value :value)))
       :ptuple (/ (group (* "(" :root (+ ")" (error)))) ,(pnode :ptuple))
       :btuple (/ (group (* "[" :root (+ "]" (error)))) ,(pnode :btuple))
       :struct (/ (group (* "{" :root2 (+ "}" (error)))) ,(pnode :struct))

--- a/test/suite0.janet
+++ b/test/suite0.janet
@@ -4,43 +4,50 @@
 (start-suite 0)
 
 # only testing format-print as other fns are dependent on it
-(def b @"")
-(with-dyns [:out b]
-  (fmt/format-print "(\n print\n \"HOHOHO\")"))
-(assert (deep= b @"(print\n  \"HOHOHO\")\n") "format-print")
+(do
+  (def res
+    (capture-stdout
+      (fmt/format-print "(\n print\n  \"HOHOHO\")")))
+  (assert (= res [nil "(print\n  \"HOHOHO\")\n"]) "format-print"))
 
 # regresion with comment in the collection literals
-(buffer/clear b)
-(with-dyns [:out b]
-  (fmt/format-print "{:a 0\n:b 1 # test comment\n}"))
-(assert (deep= b @"{:a 0\n :b 1 # test comment\n}\n") "format-print comment in collection 1")
+(do
+  (def res
+    (capture-stdout
+      (fmt/format-print "{:a 0\n:b 1 # test comment\n}")))
+  (assert (= res [nil "{:a 0\n :b 1 # test comment\n}\n"]) "format-print comment in collection 1"))
 
-(buffer/clear b)
-(with-dyns [:out b]
-  (fmt/format-print "[:a       0\n:b\n# test comment\n]"))
-(assert (deep= b @"[:a 0\n :b\n # test comment\n]\n") "format-print comment in collection 2")
+(do
+  (def res
+    (capture-stdout
+      (fmt/format-print "[:a       0\n:b\n# test comment\n]")))
+  (assert (= res [nil "[:a 0\n :b\n # test comment\n]\n"]) "format-print comment in collection 2"))
 
-(buffer/clear b)
-(with-dyns [:out b]
-  (fmt/format-print "()"))
-(assert (deep= b @"()\n") "format-print ()")
+(do
+  (def res
+    (capture-stdout
+      (fmt/format-print "()")))
+  (assert (= res [nil "()\n"]) "format-print empty form"))
 
-(buffer/clear b)
-(with-dyns [:out b]
-  (fmt/format-print "( )"))
-(assert (deep= b @"()\n") "format-print ( )")
+(do
+  (def res
+    (capture-stdout
+      (fmt/format-print "( )")))
+  (assert (= [nil "()\n"]) "format-print empty form with whitespace"))
 
-(buffer/clear b)
-(with-dyns [:out b]
-  (fmt/format-print "# a comment"))
-(assert (deep= b @"# a comment\n\n") "format-print only comment")
+(do
+  (def res
+    (capture-stdout
+      (fmt/format-print "# a comment")))
+  (assert (= [nil "# a comment\n\n"]) "format-print only comment"))
 
-(buffer/clear b)
-(with-dyns [:out b]
-  (try
-    (fmt/format-print "print )")
-    ([err]
-     (print "error"))))
-(assert (deep= b @"error\n") "format-print errors with unbalanced parenthesis")
+(do
+  (def res
+    (capture-stdout
+      (try
+        (fmt/format-print "print )")
+        ([err]
+         (print "error")))))
+  (assert (= [nil "error\n"]) "format-print errors with unbalanced parenthesis"))
 
 (end-suite)

--- a/test/suite0.janet
+++ b/test/suite0.janet
@@ -25,4 +25,15 @@
   (fmt/format-print "()"))
 (assert (deep= b @"()\n") "format-print ()")
 
+(buffer/clear b)
+(with-dyns [:out b]
+  (fmt/format-print "( )"))
+(assert (deep= b @"()\n") "format-print ( )")
+
+(buffer/clear b)
+(with-dyns [:out b]
+  (fmt/format-print "# a comment"))
+(pp b)
+(assert (deep= b @"# a comment\n\n") "format-print only comment")
+
 (end-suite)

--- a/test/suite0.janet
+++ b/test/suite0.janet
@@ -33,7 +33,14 @@
 (buffer/clear b)
 (with-dyns [:out b]
   (fmt/format-print "# a comment"))
-(pp b)
 (assert (deep= b @"# a comment\n\n") "format-print only comment")
+
+(buffer/clear b)
+(with-dyns [:out b]
+  (try
+    (fmt/format-print "print )")
+    ([err]
+     (print "error"))))
+(assert (deep= b @"error\n") "format-print errors with unbalanced parenthesis")
 
 (end-suite)


### PR DESCRIPTION
The PEG used by the fmt defines the rule `:value` as a sequence requiring at least one match for both `:spacing` and`:rawvalue`. This causes the formatter not to work as expected with empty forms or files containing only comments.

This PR addresses the problem by moving the initial `:spacing` from `:value` to be the initial value in `:root` and `:root2`. Tests are added to the test suite to confirm the correct behaviour.

This PR fixes #17 and fixes #19.