### PR TITLE
Set run-context parser in netrepl/server

### DIFF
--- a/spork/netrepl.janet
+++ b/spork/netrepl.janet
@@ -106,6 +106,7 @@
         (set name (or (recv) (break)))
         (print "client " name " connected")
         (def e (coerce-to-env env name stream))
+        (def p (parser/new))
         (var is-first true)
         (defn getline-async
           [prmpt buf]
@@ -137,9 +138,10 @@
              :on-compile-error (wrapio bad-compile)
              :on-parse-error (wrapio bad-parse)
              :evaluator (fn [x &] (setdyn :out outbuf) (setdyn :err outbuf) (x))
-             :source "repl"})
+             :source "repl"
+             :parser p})
           coro
-          (fiber/setenv (table/setproto @{:out outbuf :err outbuf} e))
+          (fiber/setenv (table/setproto @{:out outbuf :err outbuf :parser p} e))
           resume))
       (print "closing client " name))))
 

--- a/test/suite8.janet
+++ b/test/suite8.janet
@@ -1,5 +1,5 @@
 (import ../spork/temple :as temple)
-(import spork/test)
+(import ../spork/test)
 
 (temple/add-loader)
 


### PR DESCRIPTION
This PR:

1. creates a parser in the `netrepl/server` function body;
2. passes this to `run-context`; and
3. adds a dynamic reference to the server environment.

It also fixes a bug in `test/suite08.janet`.

## Rationale

At present, `netrepl/server` doesn't specify the parser to use when it calls `run-context`. This means that there is no way to manipulate the parser that parses Janet code received from the netrepl client.

The primary reason a client would want to manipulate the parser is so it can set the parser's line and column using `parser/where`. This is important for editor plugins like [Conjure](https://conjure.fun) that function as netrepl clients and send code from the editor to the netrepl server. If that code contains an error, the error message will refer to the 'line number' where the error occurred but this 'line number' is not the line number in the file currently being edited. Instead it is the total number of lines that the netrepl client has sent to the netrepl server at the point the error occurred. If an editor client could set the line number before it sent the code to be evaluated, errors produced would refer to the correct line number and be more useful. 

## Example

An out-of-band command (i.e. a message that beings with the `0xFF`) that manipulates the parser can be sent like so:

```janet
"\xFF(parser/where (dyn :parser) 120)"
```

## Notes

@bakpakin I'm not sure if using a dynamic reference as I'm doing here is the best approach. Happy to make changes if there's a more appropriate way to do so.