### PR TITLE
Support arguments to out-of-band commands in netrepl/server

### DIFF
--- a/test/suite8.janet
+++ b/test/suite8.janet
@@ -9,9 +9,9 @@
   [template args expected]
   (def buf @"")
   (with-dyns [:out buf]
-    (template args)
-    (def sbuf (string/trim (string buf)))
-    (test/assert (= sbuf expected) (string "Render of " template))))
+    (template args))
+  (def sbuf (string/trim (string buf)))
+  (test/assert (= sbuf expected) (string "Render of " template)))
 
 (import ./templates/hi :as hi)
 (import ./templates/hop :as hop)

--- a/test/suite9.janet
+++ b/test/suite9.janet
@@ -1,0 +1,47 @@
+(use ../spork/test)
+(import ../spork/msg)
+(import ../spork/netrepl)
+
+(start-suite 9)
+
+(defn wrk [m]
+  (netrepl/server "localhost" "8000"))
+
+(def wt (thread/new wrk 1 :h)) # we need heavy thread for the assert
+
+(os/sleep 0.1) # give server thread little time to start
+
+(defer (:close wt)
+  (def s (net/connect "localhost" "8000"))
+  (def recv (msg/make-recv s))
+  (def send (msg/make-send s))
+  (send "test")
+
+  (assert (= (recv) "test:1: ") "Prompt 1")
+  (send "(+ 1 2)\n")
+  (assert (= (recv) "\e[32m3\e[0m\n") "Result 1")
+
+  (assert (= (recv) "test:2: ") "Prompt 2")
+  (send "\xFF(parser/where (dyn :parser) 100)")
+  (assert (= (recv) "(true (100 0))") "Response 2")
+  (send "(+ 1 2)\n")
+  (assert (= (recv) "\e[32m3\e[0m\n") "Result 2")
+
+  (assert (= (recv) "test:101: ") "Prompt 3")
+  (send "\xFEcancel")
+  (assert (= (recv) nil) "Response 3")
+
+  (assert (= (recv) "test:101: ") "Prompt 4")
+  (send "\xFEsource \"foobar.janet\"")
+  (assert (= (recv) nil) "Response 4")
+
+  (assert (= (recv) "test:101: ") "Prompt 5")
+  (send "(def foo :bar)\n")
+  (assert (= (recv) "\e[33m:bar\e[0m\n") "Result 5")
+
+  (assert (= (recv) "test:102: ") "Prompt 6")
+  (send "(get (dyn 'foo) :source-map)\n")
+  (assert (= (recv) "(\e[35m\"foobar.janet\"\e[0m \e[32m101\e[0m \e[32m1\e[0m)\n") "Result 6")
+
+  (assert (= (recv) "test:103: ") "Prompt 7"))
+(end-suite)


### PR DESCRIPTION
This PR adds support for out-of-band commands to `netrepl/server` being sent with space-delimited arguments.

## Implementation

This PR uses a PEG to parse the message into a command and then zero or more arguments. The command is converted into a keyword and the remaining arguments are parsed into Janet values using `parse`. The PEG separates the elements by using the ` ` and `\t` characters as delimiters. This value is assigned to the value `ret` that is returned by the `getline-async` function defined in `netrepl/server` (this function is used by the `chunks` function that is passed to `run-context`).

This means that if a netrepl client sends the following message to the server:

```janet
"\xFEsource \"foobar.janet\""
```

the following value will be returned by the `chunks` function used in `run-context`:

```janet
[:source "foobar.janet"]
```

To retain compatibility, if the command has no arguments, only the command (e.g. `:cancel`) is sent and not the array returned by `peg/match`.

## Background

Currently, an out-of-band message command can be sent to `netrepl/server` by prepending the message with the `\xFE` byte. Messages that are prefixed with this byte are turned into keywords and then returned as the result of the `chunks` function used in `run-context`. Since the entire message (less the `\xFE` byte) is turned into a keyword, it is not possible to provide arguments to the command.

This PR is the third part of a larger project to improve REPL-based tooling for Janet. Previously:

1. a custom parser object was added to `netrepl/server` that could be manipulated by a netrepl client (#33); and
2. support was added for manipulation of the source location used by `run-context` (janet-lang/janet#642).

The changes to `run-context` mean that a value of the form `[:source "<new-location>"]` now cause the `where` value used inside `run-context` to be updated to the new location. A fuller explanation of why this is useful for tooling is included in janet-lang/janet#642.

This PR will result in the `chunks` function returning a value of the form `[<command> <arg1> <arg2> <arg3> ... <argn>]` when an out-of-band command is sent to the netrepl server. The implementation is designed so that support for future commands can be added to `run-context` without requiring additional changes to `netrepl/server`.

## Notes

Random thoughts that don't fit anywhere else:

* Hindsight is 20/20 but it would have been more consistent to have used the mechanism added by this PR to manipulate `run-context`'s parser rather than the mechanism added by #33. In other words, a netrepl client could have sent the message `"\xFEposition <line-num> (<col-num>)"` and `run-context` would have updated its parser accordingly. @bakpakin If that approach is preferred, let me know and I can make a PR to `run-context` that would support this.

* ~There is currently a PR outstanding to fix a bug in the `match` statement added in janet-lang/janet#642 (janet-lang/janet#646). Until that PR is accepted, the functionality in this PR won't work.~

* This PR adds a test suite that tests `netrepl/server`. This suite was mentioned in #33. I could not find a way to silence the output `Starting networked repl server on localhost, port 8000...` and `client test connected` and just left it as-is.