### PR TITLE
Add `temple/compile` function

### DIFF
--- a/spork/temple.janet
+++ b/spork/temple.janet
@@ -137,3 +137,23 @@
   []
   (put module/loaders :temple loader)
   (module/add-paths ".temple" :temple))
+
+#
+# String templating
+#
+
+(defn compile
+  `
+  Compile a Temple template into a function which will return a
+  rendered buffer.
+
+  The resulting function should receive the template arguments in the
+  &keys format.
+  `
+  [str]
+  (let [tmpl (create str)]
+    (fn render
+      [&keys args]
+      (let [out @""]
+        (with-dyns [:out out] (tmpl args))
+        out))))

--- a/spork/temple.janet
+++ b/spork/temple.janet
@@ -151,7 +151,7 @@
   &keys format.
   `
   [str]
-  (let [tmpl (create str)]
+  (let [tmpl (create str (dyn :current-file))]
     (fn render
       [&keys args]
       (let [out @""]

--- a/test/suite8.janet
+++ b/test/suite8.janet
@@ -30,4 +30,13 @@
                 </html>
                 ```)
 
+(def str-template "<html>hello {{ (args :arg) }}</html>")
+(def render (temple/compile str-template))
+(def out (render :arg "world"))
+
+(test/assert (buffer? out) "Rendered temple string produces a buffer")
+
+(def expected "<html>hello world</html>")
+(test/assert (= expected (string out)) "Rendered temple string produces \"hello world\"")
+
 (test/end-suite)


### PR DESCRIPTION
This exposes the same temple templating functionality as a function that takes a template string.

This allows on-the-fly templating without creating a template file.