### PR TITLE
Add capture-err and suppress-err macros, fix fmt tests

### DIFF
--- a/doc/test.mdz
+++ b/doc/test.mdz
@@ -102,9 +102,8 @@ stdout in string.
 
 @codeblock[janet]```
 (capture-stdout
-  (do
-    (print "Interesting output")
-    true))
+  (print "Interesting output")
+  true)
 # => (true "Interesting output")
 ```
 

--- a/spork/test.janet
+++ b/spork/test.janet
@@ -71,18 +71,30 @@
        (print ,tag " " (- ,end ,start) " seconds")
        ,result)))
 
+(defmacro- capture-*
+  [out form]
+  (with-syms [buf res]
+    ~(do
+       (def ,buf @"")
+       (with-dyns [,out ,buf]
+         (def ,res ,form)
+         [,res (string ,buf)]))))
+
 (defmacro capture-stdout
   ```
   Runs the form and captures stdout. Returns tuple with result of the form
   and a string with captured stdout.
   ```
   [form]
-  (with-syms [buf res]
-    ~(do
-       (def ,buf @"")
-       (with-dyns [:out ,buf]
-         (def ,res ,form)
-         [,res (string ,buf)]))))
+  ~(as-macro ,capture-* :out ;,form))
+
+(defmacro capture-stderr
+  ```
+  Runs the form and captures stderr. Returns tuple with result of the form
+  and a string with captured stderr.
+  ```
+  [form]
+  ~(as-macro ,capture-* :err ;,form))
 
 (defmacro suppress-stdout [& body]
   "Suppreses stdout from the body"

--- a/spork/test.janet
+++ b/spork/test.janet
@@ -72,12 +72,13 @@
        ,result)))
 
 (defmacro- capture-*
-  [out form]
+  [out & forms]
+  (tracev forms)
   (with-syms [buf res]
     ~(do
        (def ,buf @"")
        (with-dyns [,out ,buf]
-         (def ,res ,form)
+         (def ,res (do ,;forms))
          [,res (string ,buf)]))))
 
 (defmacro capture-stdout
@@ -85,16 +86,16 @@
   Runs the form and captures stdout. Returns tuple with result of the form
   and a string with captured stdout.
   ```
-  [form]
-  ~(as-macro ,capture-* :out ;,form))
+  [& forms]
+  ~(as-macro ,capture-* :out ,;forms))
 
 (defmacro capture-stderr
   ```
   Runs the form and captures stderr. Returns tuple with result of the form
   and a string with captured stderr.
   ```
-  [form]
-  ~(as-macro ,capture-* :err ;,form))
+  [& forms]
+  ~(as-macro ,capture-* :err ,;forms))
 
 (defmacro suppress-stdout [& body]
   "Suppreses stdout from the body"

--- a/spork/test.janet
+++ b/spork/test.janet
@@ -72,13 +72,12 @@
        ,result)))
 
 (defmacro- capture-*
-  [out & forms]
-  (tracev forms)
+  [out & body]
   (with-syms [buf res]
     ~(do
        (def ,buf @"")
        (with-dyns [,out ,buf]
-         (def ,res (do ,;forms))
+         (def ,res (do ,;body))
          [,res (string ,buf)]))))
 
 (defmacro capture-stdout
@@ -86,17 +85,24 @@
   Runs the form and captures stdout. Returns tuple with result of the form
   and a string with captured stdout.
   ```
-  [& forms]
-  ~(as-macro ,capture-* :out ,;forms))
+  [& body]
+  ~(as-macro ,capture-* :out ,;body))
 
 (defmacro capture-stderr
   ```
   Runs the form and captures stderr. Returns tuple with result of the form
   and a string with captured stderr.
   ```
-  [& forms]
-  ~(as-macro ,capture-* :err ,;forms))
+  [& body]
+  ~(as-macro ,capture-* :err ,;body))
+
+(defmacro- suppress-* [out & body]
+  ~(with-dyns [,out @""] ,;body))
 
 (defmacro suppress-stdout [& body]
   "Suppreses stdout from the body"
-  ~(with-dyns [:out @""] ,;body))
+  ~(as-macro ,suppress-* :out ,;body))
+
+(defmacro suppress-stderr [& body]
+  "Suppreses stdout from the body"
+  ~(as-macro ,suppress-* :err ,;body))

--- a/test/suite0.janet
+++ b/test/suite0.janet
@@ -46,8 +46,7 @@
     (capture-stdout
       (try
         (fmt/format-print "print )")
-        ([err]
-         (print "error")))))
+        ([err] (print "error")))))
   (assert (= res [nil "error\n"]) "format-print errors with unbalanced parenthesis"))
 
 (end-suite)

--- a/test/suite0.janet
+++ b/test/suite0.janet
@@ -33,13 +33,13 @@
   (def res
     (capture-stdout
       (fmt/format-print "( )")))
-  (assert (= [nil "()\n"]) "format-print empty form with whitespace"))
+  (assert (= res [nil "()\n"]) "format-print empty form with whitespace"))
 
 (do
   (def res
     (capture-stdout
       (fmt/format-print "# a comment")))
-  (assert (= [nil "# a comment\n\n"]) "format-print only comment"))
+  (assert (= res [nil "# a comment\n\n"]) "format-print only comment"))
 
 (do
   (def res
@@ -48,6 +48,6 @@
         (fmt/format-print "print )")
         ([err]
          (print "error")))))
-  (assert (= [nil "error\n"]) "format-print errors with unbalanced parenthesis"))
+  (assert (= res [nil "error\n"]) "format-print errors with unbalanced parenthesis"))
 
 (end-suite)

--- a/test/suite7.janet
+++ b/test/suite7.janet
@@ -14,10 +14,11 @@
 (assert (test/assert-no-error "assert-no-error" "Good"))
 
 # test/capture-stdout
-(test/assert (= [true "Output\n"] (test/capture-stdout (do (print "Output") true))) "capture stdout")
+(test/assert (= [true "Output\n"] (test/capture-stdout (print "Output") true)) "capture stdout")
 
-# test/capture-stdout
-(test/assert (= [true "Output\n"] (test/capture-stderr (do (eprint "Output") true))) "capture stderr")
+# test/capture-stderr
+(test/assert (= [true "Output\n"]
+                (test/capture-stderr (eprint "Output") true)) "capture stderr")
 
 # test/timeit
 (do
@@ -42,10 +43,9 @@
 (test/assert
   (= [nil "\nRunning test suite 666 tests...\n\n\e[32m\xE2\x9C\x94\e[0m\n\nTest suite 666 finished in 0.000 soconds\n13 of 13 tests passed.\n\n"])
   (test/capture-stdout
-    (do
-      (test/start-suite 666)
-      (test/assert true "true")
-      (test/end-suite))))
+    (test/start-suite 666)
+    (test/assert true "true")
+    (test/end-suite)))
 
 # test/suppress-stdout
 (test/assert

--- a/test/suite7.janet
+++ b/test/suite7.janet
@@ -14,7 +14,10 @@
 (assert (test/assert-no-error "assert-no-error" "Good"))
 
 # test/capture-stdout
-(test/assert (= [true "Output\n"] (test/capture-stdout (do (print "Output") true))) "capture output")
+(test/assert (= [true "Output\n"] (test/capture-stdout (do (print "Output") true))) "capture stdout")
+
+# test/capture-stdout
+(test/assert (= [true "Output\n"] (test/capture-stderr (do (eprint "Output") true))) "capture stderr")
 
 # test/timeit
 (do

--- a/test/suite7.janet
+++ b/test/suite7.janet
@@ -54,4 +54,11 @@
        (test/suppress-stdout (print "Hello world!"))))
   "suppress-stdout")
 
+# test/suppress-stdout
+(test/assert
+  (= [nil ""]
+     (test/capture-stderr
+       (test/suppress-stderr (print "Hello world!"))))
+  "suppress-stderr")
+
 (test/end-suite)


### PR DESCRIPTION
Sometimes it is good to be able to capture `stderr` too. It is implemented with the new `as-macro` macro as an exercise :).

This commit also fixes fmt tests, where we have not checked the result of the call. This I can move to separate PR if desirable.

If you would like to, I can also add a `suppress-err` macro akin to `suppress-stdout` implemented the same way to this PR or to separate one.