### PR TITLE
Fix reading request from connection in http

### DIFF
--- a/test/suite0012.janet
+++ b/test/suite0012.janet
@@ -46,4 +46,12 @@
   (test-http-item (http/request "GET" "http://127.0.0.1:9816") nil nil 200
                   {"content-length" "1"}))
 
+(defn body-server
+  [req]
+  {:status 200 :body (string (http/read-body req))})
+
+(with [server (http/server body-server "127.0.0.1" 9816)]
+  (test-http-item (http/request "POST" "http://127.0.0.1:9816"
+                                :body "Strong and healthy")
+                  nil nil 200 {"content-length" "18"}))
 (end-suite)

--- a/test/suite0012.janet
+++ b/test/suite0012.janet
@@ -54,4 +54,10 @@
   (test-http-item (http/request "POST" "http://127.0.0.1:9816"
                                 :body "Strong and healthy")
                   nil nil 200 {"content-length" "18"}))
+
+(with [server (http/server body-server "127.0.0.1" 9816)]
+  (test-http-item (http/request "POST" "http://127.0.0.1:9816"
+                                :body (string/repeat "a" 2097152))
+                  nil nil 200 {"content-length" "2097152"}))
+
 (end-suite)


### PR DESCRIPTION
Namely, I removed the dst-end argument in pre-pop, as we want it to the end anyway. And I removed the pre-pop from read-body, as the buffer is already pre-poped.

Also, fix the default port and some typos.

This PR also makes some private functions public, as developers can use them in other libraries. If it is not desirable, please let me know, and I remove these changes.