### PR TITLE
Add concat chunk

### DIFF
--- a/spork/temple.janet
+++ b/spork/temple.janet
@@ -78,6 +78,12 @@
     (code-chunk
       (string "\n(prin (do " str "\n)) ")))
 
+  (defn concat-chunk
+    "Insert concat chunk into parser"
+    [str]
+    (code-chunk
+      (string "\n(prin (string " str "\n)) ")) )
+
   (defn string-chunk
     "Insert string chunk into parser"
     [str]
@@ -91,8 +97,10 @@
       :compile-time-chunk (* "{$" (drop (cmt '(any (if-not "$}" 1)) ,compile-time-chunk)) "$}")
       :sub-chunk (* "{{" (drop (cmt '(any (if-not "}}" 1)) ,sub-chunk)) "}}")
       :raw-chunk (* "{-" (drop (cmt '(any (if-not "-}" 1)) ,raw-chunk)) "-}")
+      :contat-chunk (* "{." (drop (cmt '(any (if-not ".}" 1)) ,concat-chunk)) ".}")
       :main-chunk (drop (cmt '(any (if-not (+ "{$" "{{" "{%" "{-") 1)) ,string-chunk))
-      :main (any (+ :compile-time-chunk :raw-chunk :code-chunk :sub-chunk :main-chunk (error "")))})
+      :main (any (+ :compile-time-chunk :raw-chunk :code-chunk :sub-chunk
+                    :contat-chunk :main-chunk (error "")))})
   (def did-match (peg/match grammar source))
 
   # Check errors in template and parser

--- a/test/suite0008.janet
+++ b/test/suite0008.janet
@@ -39,4 +39,8 @@
 (def expected "<html>hello world</html>")
 (test/assert (= expected (string out)) "Rendered temple string produces \"hello world\"")
 
+(test/assert (deep= ((temple/compile `{. (args :a) " * 2 = " (args :b) .}`) :a 1 :b 2)
+                    @"1 * 2 = 2")
+             "concat chunk")
+
 (test/end-suite)


### PR DESCRIPTION
In my web development, I have found that many times I concat some pre-rendered strings from the helpers:

```
{- (string (link "somewhere") (do-not-click "somewhere link")) -}
```

So I thought it would be good to have a particular type of chunk that does just that:

```
{. (link "somewhere") (do-not-click "somewhere link") .}
```

What do you think?