### PR TITLE
Fix read body and add auto body read in request

### DIFF
--- a/spork/http.janet
+++ b/spork/http.janet
@@ -179,10 +179,10 @@
           :connection conn
           :head-size head-size} req)
     (def content-length (scan-number cl))
-    (def remaining (- content-length (length buf)))
+    (def remaining (- content-length (- (length buf) head-size)))
     (when (pos? remaining)
       (ev/chunk conn remaining buf))
-    (put req :body buf)
+    (put req :body (buffer/slice buf head-size))
     (break buf))
 
   # TODO - Chunked encoding
@@ -298,6 +298,7 @@
 
     # Parse response pure janet
     (def res (read-response conn buf))
+    (read-body res)
     (when (= :error res) (error res))
 
     # TODO - handle redirects with Location header

--- a/test/suite0012.janet
+++ b/test/suite0012.janet
@@ -60,4 +60,9 @@
                                 :body (string/repeat "a" 2097152))
                   nil nil 200 {"content-length" "2097152"}))
 
+(with [server (http/server body-server "127.0.0.1" 9816)]
+  (test-http-item (http/request "POST" "http://127.0.0.1:9816"
+                                :body (string/repeat "a" 4194304))
+                  nil nil 200 {"content-length" "4194304"}))
+
 (end-suite)

--- a/test/suite0012.janet
+++ b/test/suite0012.janet
@@ -51,18 +51,21 @@
   {:status 200 :body (string (http/read-body req))})
 
 (with [server (http/server body-server "127.0.0.1" 9816)]
-  (test-http-item (http/request "POST" "http://127.0.0.1:9816"
-                                :body "Strong and healthy")
-                  nil nil 200 {"content-length" "18"}))
+  (def res (http/request "POST" "http://127.0.0.1:9816" :body "Strong and healthy"))
+  (test-http-item res nil nil 200 {"content-length" "18"})
+  (assert (= (length (res :body)) 18)
+          "actual body length"))
 
 (with [server (http/server body-server "127.0.0.1" 9816)]
-  (test-http-item (http/request "POST" "http://127.0.0.1:9816"
-                                :body (string/repeat "a" 2097152))
-                  nil nil 200 {"content-length" "2097152"}))
+  (def res (http/request "POST" "http://127.0.0.1:9816" :body (string/repeat "a" 2097152)))
+  (test-http-item res nil nil 200 {"content-length" "2097152"})
+  (assert (= (length (res :body)) 18)
+          "actual body length"))
 
 (with [server (http/server body-server "127.0.0.1" 9816)]
-  (test-http-item (http/request "POST" "http://127.0.0.1:9816"
-                                :body (string/repeat "a" 4194304))
-                  nil nil 200 {"content-length" "4194304"}))
+  (def res (http/request "POST" "http://127.0.0.1:9816" :body (string/repeat "a" 4194304)))
+  (test-http-item res nil nil 200 {"content-length" "4194304"})
+  (assert (= (length (res :body)) 18)
+          "actual body length"))
 
 (end-suite)


### PR DESCRIPTION
When investigating the large body problem mentioned in #45, I have found that it has nothing to do with Janet reading. It was just that we were not reading the body of the response in `request`, so when the server wanted to write the whole body, the connection was already closed on the reading side.

The first commit adds implicit body read to `request` as it is what you usually want. After the function runs, there is no way to read it later as the connection is already closed.

With this change I have found, we computed the remaining size wrong, as we did not account for the header size, so I fixed `read-body` in this regard.