### PR TITLE
Add GitHub workflow to automate tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: "Test project"
+      uses: pyrmont/action-janet-test@v2


### PR DESCRIPTION
This adds a GitHub workflow that uses my [action-janet-test](https://github.com/pyrmont/action-janet-test) GitHub Action. That action bundles together a number of different steps:

1. downloading Janet
2. installing Janet
3. downloading JPM
4. installing JPM
5. checking out this repository
6. installing any dependencies (in this case there are none)
7. running `jpm test`

You can see similar workflows in use in some of my Janet libraries (e.g. [Documentarian](https://github.com/pyrmont/documentarian/blob/cf63fb60bc03329ea6d8400e18593b3957136581/.github/workflows/build.yml) and [Testament](https://github.com/pyrmont/testament/blob/7ff23c4b28c1364dd6206cfd483e4c437f289860/.github/workflows/build.yml)).