### PR TITLE
Add badge to README

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test
+name: Test
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Spork
 
+[![test](https://github.com/janet-lang/spork/actions/workflows/test.yml/badge.svg)](https://github.com/janet-lang/spork/actions/workflows/test.yml)
+
 Various Janet utility modules. Spork aims to be grab bag of useful Janet functionality that
 does not belong in the core library.
 


### PR DESCRIPTION
I should have added a badge to the README in #52. This also corrects the name of the job so that it's `test`.