### PR TITLE
Add schema module to init for importing

### DIFF
--- a/spork/init.janet
+++ b/spork/init.janet
@@ -10,5 +10,6 @@
 (import ./path :export true)
 (import ./regex :export true)
 (import ./rpc :export true)
+(import ./schema :export true)
 (import ./temple :export true)
 (import ./test :export true)


### PR DESCRIPTION
This PR adds `schema` module to `spork/init` for convenient import.