### PR TITLE
Fix error messages not printing in netrepl server

### DIFF
--- a/spork/netrepl.janet
+++ b/spork/netrepl.janet
@@ -77,7 +77,7 @@
     (put nextenv :debug-level level)
     (put nextenv :signal x)
     (merge-into nextenv debugger-env)
-    (debug/stacktrace f x)
+    (debug/stacktrace f x "")
     (eflush)
     (defn debugger-chunks [buf p]
       (def status (parser/state p :delimiters))
@@ -95,7 +95,7 @@
       (do (put e '_ @{:value x}) (pp x))
       (if (e :debug)
         (enter-debugger f x)
-        (do (debug/stacktrace f x) (eflush))))))
+        (do (debug/stacktrace f x "") (eflush))))))
 
 (defn server
   "Start a repl server. The default host is \"127.0.0.1\" and the default port


### PR DESCRIPTION
Currently, errors that occur during evaluation of code by the netrepl server result in only a stacktrace being sent to the client, no error message is sent. The cause of this is a change made in Janet 1.19.1 that allowed for an optional prefix parameter to be provided to `debug/stacktrace` ([changelog](https://github.com/janet-lang/janet/releases/tag/v1.19.1)). Although this parameter is optional in the sense that it does not need to be provided, if `debug/stacktrace` is called without providing a string prefix, the error message will not be printed (the stacktrace is still printed).

This PR adds an empty string prefix to the calls to `debug/stacktrace`. This [mirrors the approach](https://github.com/janet-lang/janet/commit/e8c738002bebe7bacd1b1ede3376a98b896f8f6f) taken to updating `debug/stacktrace` calls within `boot.janet`.