### PR TITLE
http: Detect end-of-header in read-header even when not on a packet boundary

### DIFF
--- a/spork/http.janet
+++ b/spork/http.janet
@@ -62,7 +62,7 @@
                  key2 b})
              :error))
       (break))
-    (set last-index (length buf))
+    (set last-index (max 0 (- (length buf) 4)))
     (ev/read conn chunk-size buf))
   head)
 


### PR DESCRIPTION
The previous implementation would fail if \r\n\r\n weren't sent in a single packet, since it looks for it only on the boundaries of packets as returned by ev/read. This makes it look at least 4 bytes backwards – the performance difference should be minimal.

This was actually encountered using a derivation of spork/http with TLS support while communicating with an OpenWrt router (uhttpd), which output something similar to the test case, where the trailing \r\n was in its own TLS record, and read-header would skip over it. (Worse yet, with Transfer-Encoding: chunked, it also consumed the chunk data, because the closest \r\n\r\n was after the zero-length trailing chunk, making the body instead be empty.)

A test case is attached that illustrates this. Sorry if it's somewhat contrived.