### PR TITLE
Make rawterm example work with getch

### DIFF
--- a/examples/rawterm.janet
+++ b/examples/rawterm.janet
@@ -11,11 +11,10 @@
   (rawterm/begin on-winch)
   (forever
     (buffer/clear buf)
-    (def c (rawterm/getch))
+    (def [c] (rawterm/getch))
     (case c
       (chr "a") (print "Got an A an for Alan!")
       (chr "b") (print "Got a B for Bobby!")
       (chr "c") (print "Got a C for Calvin")
       (chr "z") (do (print "quitting...") (break))
       (printf "got a %c for something..." c))))
-


### PR DESCRIPTION
`rawterm/getch` returns buffer and not char.