### PR TITLE
Remove unused buffer for rawterm example, ignore jpm_tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ _develop
 _release
 _out
 _debug
+
+jpm_tree

--- a/examples/rawterm.janet
+++ b/examples/rawterm.janet
@@ -6,11 +6,9 @@
 
 (print "press z to quit")
 
-(def buf @"")
 (defer (rawterm/end)
   (rawterm/begin on-winch)
   (forever
-    (buffer/clear buf)
     (def [c] (rawterm/getch))
     (case c
       (chr "a") (print "Got an A an for Alan!")


### PR DESCRIPTION
The first issue is a remnant of the old API. Adding jpm_tree to git ignored paths is an excellent thing to do in any Janet codebase, in my opinion.