### PR TITLE
added spork/relpath

### DIFF
--- a/test/suite0020.janet
+++ b/test/suite0020.janet
@@ -1,0 +1,14 @@
+(use ../spork/test)
+(import ../spork/path)
+
+(start-suite 20)
+
+(assert (= (path/posix/relpath "dir1" "dir2") "../dir2"))
+
+(assert (= (path/win32/relpath "dir1" "dir2") "..\\dir2"))
+
+(assert (= (path/relpath "dir1" "dir2") (path/join ".." "dir2")))
+
+(assert (= (path/posix/relpath "a/bit/deeper/with/some/nested/dir" "a/bit/deeper/with/other/nested/dir") "../../../other/nested/dir"))
+
+(end-suite)


### PR DESCRIPTION
Returns the relative path between two subpaths
this should imitate the behaviour of e.g.
```bash
realpath --relative-to="a/bit/deeper/with/some/nested/dirs" "a/bit/deeper/with/other/nested/dirs"
```

I wrote a few tests for it in a new test suite.
