### PR TITLE
New module: `data.janet` and test suite 0021

### DIFF
--- a/doc/data.mdz
+++ b/doc/data.mdz
@@ -1,0 +1,37 @@
+{:title "data"
+ :author "Caleb Figgers"
+ :license "MIT"
+ :template "mdzdoc/main.html"
+ :order 0}
+---
+Clojure contains a very useful core library called @link[https://github.com/clojure/clojure/blob/51c6d7a70912a8f65e81a8e11ae6f56c94920725/src/clj/clojure/data.clj]{clojure.data}. It contains one "exported" function: @code`clojure.data/diff`. This addition to spork, @code`data.janet`, should exactly replicate the behavior of @code`clojure.data/diff` using Janet tables, structs, arrays, and tuples in place of their Clojure equivalents.
+
+## Function
+
+The @code`diff` function recursively compares the structure and contents of two data structures (struct, table, tuple, array) and returns an array with three elements:
+
+@code`@[things-only-in-a things-only-in-b things-in-both]`
+
+In the case of nested maps, the comparison is recursive and the data structures are neatly partitioned into the same @code`@[things-only-in-a things-only-in-b things-in-both]` structure, but arbitrary levels deep in the two original associative data structures.
+
+This function makes comparing two structs or tables for changes trivial. (An example use case: compare the decoded JSON returned from a REST API call made seconds ago against the version of that same decoded JSON from that same API that was returned from the same call made an hour ago and stored locally in a database for comparison an hour later.)
+
+## Example
+
+So for example, @code`diff`'ing the two nested structs @code`{:a 1 :b 2 :c {:d 3 :e 4}}` and @code`{:a 4 :b 2 :c {:d 3 :e 5 :f 6}}` looks like this:
+
+@codeblock[janet]```
+repl:1:> (import spork/data :as d)
+repl:2:> (d/diff {:a 1 :b 2 :c {:d 3 :e 4}} {:a 4 :b 2 :c {:d 3 :e 5 :f 6}})
+@[@{:a 1 :c @{:e 4}} @{:a 4 :c @{:e 5 :f 6}} @{:b 2 :c @{:d 3}}]
+```
+
+The return is @code`@[@{:a 1 :c @{:e 4}} @{:a 4 :c @{:e 5 :f 6}} @{:b 2 :c @{:d 3}}]` because:
+
+@ul{
+  @li{the value for @code`:a` appears in both and is different in each one (so @code`:a` is a key in both the first and second map, with each value set as seen in the first and second original maps)}
+  @li{the value for @code`:b` appears in both and is the same in each (so @code`:b` is a key only in the third map, containing the shared value in both original maps)}
+  @li{the nested value of @code`:d` appears in both and is the same in each (so @code`:c` is a key in the third map, containing the value of @code`:d` that is shared in both original maps)}
+  @li{the nested value of @code`:e` appears in both and is different in each one (so @code`:c` is a key in both the first and second map, containing the value @code`:e` with with each value set as seen in the first and second original maps), and}
+  @li{the key/value pair @code`:f` 6 only appears in the latter map (so only the second map contains @code`:f` and its value).}
+}

--- a/doc/data.mdz
+++ b/doc/data.mdz
@@ -4,7 +4,7 @@
  :template "mdzdoc/main.html"
  :order 0}
 ---
-Clojure contains a very useful core library called @link[https://github.com/clojure/clojure/blob/51c6d7a70912a8f65e81a8e11ae6f56c94920725/src/clj/clojure/data.clj]{clojure.data}. It contains one "exported" function: @code`clojure.data/diff`. This addition to spork, @code`data.janet`, should exactly replicate the behavior of @code`clojure.data/diff` using Janet tables, structs, arrays, and tuples in place of their Clojure equivalents.
+@link[https://clojure.org/]{Clojure} contains a very useful core library (or "namespace" in Clojure parlance) called @link[https://clojure.github.io/clojure/clojure.data-api.html]{clojure.data} (@link[https://github.com/clojure/clojure/blob/51c6d7a70912a8f65e81a8e11ae6f56c94920725/src/clj/clojure/data.clj]{source}). It contains one "exported" function: @code`clojure.data/diff`. This addition to spork, @code`data.janet`, should exactly replicate the behavior of @code`clojure.data/diff` using Janet tables, structs, arrays, and tuples in place of their Clojure equivalents.
 
 ## Function
 
@@ -12,7 +12,7 @@ The @code`diff` function recursively compares the structure and contents of two 
 
 @code`@[things-only-in-a things-only-in-b things-in-both]`
 
-In the case of nested maps, the comparison is recursive and the data structures are neatly partitioned into the same @code`@[things-only-in-a things-only-in-b things-in-both]` structure, but arbitrary levels deep in the two original associative data structures.
+In the case of nested associative data structures (i.e., tables and structs), the comparison is recursive and the data structures are neatly partitioned into the same @code`@[things-only-in-a things-only-in-b things-in-both]` structure, but arbitrary levels deep in the two original associative data structures.
 
 This function makes comparing two structs or tables for changes trivial. (An example use case: compare the decoded JSON returned from a REST API call made seconds ago against the version of that same decoded JSON from that same API that was returned from the same call made an hour ago and stored locally in a database for comparison an hour later.)
 
@@ -29,9 +29,9 @@ repl:2:> (d/diff {:a 1 :b 2 :c {:d 3 :e 4}} {:a 4 :b 2 :c {:d 3 :e 5 :f 6}})
 The return is @code`@[@{:a 1 :c @{:e 4}} @{:a 4 :c @{:e 5 :f 6}} @{:b 2 :c @{:d 3}}]` because:
 
 @ul{
-  @li{the value for @code`:a` appears in both and is different in each one (so @code`:a` is a key in both the first and second map, with each value set as seen in the first and second original maps)}
-  @li{the value for @code`:b` appears in both and is the same in each (so @code`:b` is a key only in the third map, containing the shared value in both original maps)}
-  @li{the nested value of @code`:d` appears in both and is the same in each (so @code`:c` is a key in the third map, containing the value of @code`:d` that is shared in both original maps)}
-  @li{the nested value of @code`:e` appears in both and is different in each one (so @code`:c` is a key in both the first and second map, containing the value @code`:e` with with each value set as seen in the first and second original maps), and}
-  @li{the key/value pair @code`:f` 6 only appears in the latter map (so only the second map contains @code`:f` and its value).}
+  @li{the value for @code`:a` appears in both and is different in each one (so @code`:a` is a key in both the first and second returned table, with each value set as seen in the first and second original structs)}
+  @li{the value for @code`:b` appears in both and is the same in each (so @code`:b` is a key only in the third returned table, containing the shared value in both original strucs)}
+  @li{the nested value of @code`:d` appears in both and is the same in each (so @code`:c` is a key in the third returned table, containing the value of @code`:d` that is shared in both original structs)}
+  @li{the nested value of @code`:e` appears in both and is different in each one (so @code`:c` is a key in both the first and second returned table, containing the value @code`:e` with with each value set as seen in the first and second original structs), and}
+  @li{the key/value pair @code`:f` 6 only appears in the latter original struct (so only the second returned table contains @code`:f` and its value).}
 }

--- a/spork/data.janet
+++ b/spork/data.janet
@@ -27,11 +27,11 @@
 
 (defn- vectorize [m]
   (unless (or (nil? m) (empty? m))
-          (when (in? (type m) [:array :tuple :table :struct])
-            (reduce
-             (fn [result [k v]] (put result k v))
-             (array/new-filled (apply max (keys m)))
-             (pairs m)))))
+    (when (in? (type m) [:array :tuple :table :struct])
+      (reduce
+        (fn [result [k v]] (put result k v))
+        (array/new-filled (apply max (keys m)))
+        (pairs m)))))
 
 (defn- diff-associative-key [a b k]
   (let [va (safe-in a k)
@@ -44,46 +44,45 @@
                       (and (nil? va) (nil? vb))))]
     [(when (and in-a (or (not (nil? a*)) (not same))) {k a*})
      (when (and in-b (or (not (nil? b*)) (not same))) {k b*})
-     (when same {k ab})
-     ]))
+     (when same {k ab})]))
 
 (defn- diff-associative [a b ks]
-  (reduce 
-   (fn [diff1 diff2]
-     (map | (if (empty? $) nil $)
-          (map | (merge (or $0 {}) (or $1 {})) diff1 diff2)))
-   [nil nil nil]
-   (map
-    (partial diff-associative-key a b)
-    ks)))
+  (reduce
+    (fn [diff1 diff2]
+      (map |(if (empty? $) nil $)
+           (map |(merge (or $0 {}) (or $1 {})) diff1 diff2)))
+    [nil nil nil]
+    (map
+      (partial diff-associative-key a b)
+      ks)))
 
 (defn- diff-sequential [a b]
   (map vectorize (diff-associative
-                  (if (array? a) a (arr a))
-                  (if (array? b) b (arr b))
-                  (range (max (length a) (length b))))))
+                   (if (array? a) a (arr a))
+                   (if (array? b) b (arr b))
+                   (range (max (length a) (length b))))))
 
 (defn- diff-similar [kind a b]
-  (cond 
+  (cond
     (in? kind [:array :tuple]) (diff-sequential a b)
     (in? kind [:table :struct]) (diff-associative a b (distinct (array/concat (keys a) (keys b))))
     (atom-diff a b)))
 
 (defn- categorize [x]
-  (cond 
+  (cond
     (in? (type x) [:array :tuple]) :sequence
     (in? (type x) [:table :struct]) :associative
     :atom))
 
-(varfn diff 
+(varfn diff
   ``` 
   Compares a and b recursively. Returns an array of 
   [things-only-in-a things-only-in-b things-in-both].   
   ```
   [a b]
   (if (= a b)
-    @[nil nil (cond (tuple? a) (apply array a) 
-                    (struct? a) (struct/to-table a) a)]
+    @[nil nil (cond (tuple? a) (apply array a)
+                (struct? a) (struct/to-table a) a)]
     (if (= (categorize a) (categorize b))
       (diff-similar (type a) a b)
       (atom-diff a b))))

--- a/spork/data.janet
+++ b/spork/data.janet
@@ -22,9 +22,6 @@
       nil)
     (in ds n)))
 
-(comment 
-  (def ds a))
-
 (defn- arr [a]
   (apply array a))
 
@@ -35,9 +32,6 @@
              (fn [result [k v]] (put result k v))
              (array/new-filled (apply max (keys m)))
              (pairs m)))))
-
-(comment 
-  (def m @{2 3}))
 
 (defn- diff-associative-key [a b k]
   (let [va (safe-in a k)
@@ -52,13 +46,6 @@
      (when (and in-b (or (not (nil? b*)) (not same))) {k b*})
      (when same {k ab})
      ]))
-
-(comment 
-  (def diff1 (diff-associative-key a b :a))
-  (def diff2 (diff-associative-key a b :b))
-  (def diff2 (diff-associative-key a b :c))
-  
-  (def k 2))
 
 (defn- diff-associative [a b ks]
   (reduce 
@@ -100,54 +87,3 @@
     (if (= (categorize a) (categorize b))
       (diff-similar (type a) a b)
       (atom-diff a b))))
-
-(comment
-  (def a {:a 1 :b 2})
-
-  (def b {:a 1 :b 3})
-
-  (def kind (type a))
-
-  (def ks (distinct (array/concat (keys a) (keys b))))
-
-  (def k (in ks 1))
-  )
-
-(comment
-  (def a 2)
-
-  (def b 3)
-
-  (def kind (type a))
-
-  (def ks (distinct (array/concat (keys a) (keys b))))
-
-  (def k (in ks 1))
-  )
-
-(comment
-  (def a [1 2])
-
-  (def b [1 2 3])
-
-  (def kind (type a))
-
-  (def ks (distinct (array/concat (keys a) (keys b))))
-
-  (def k (in ks 1))
-  )
-
-(comment
-  (def a {:map1 {:a 1 :b 2} :map2 {:c 3 :d 4}})
-
-  (def b {:map1 {:a 1 :b 2} :map2 {:c 3 :d 5}})
-
-  (def kind (type a))
-
-  (def ks (distinct (array/concat (keys a) (keys b))))
-
-  (def k (in ks 1))
-  )
-
-(comment 
-  (diff a b))

--- a/spork/data.janet
+++ b/spork/data.janet
@@ -22,15 +22,12 @@
       nil)
     (in ds n)))
 
-(defn- arr [a]
-  (apply array a))
-
 (defn- vectorize [m]
   (unless (or (nil? m) (empty? m))
     (when (in? (type m) [:array :tuple :table :struct])
       (reduce
         (fn [result [k v]] (put result k v))
-        (array/new-filled (apply max (keys m)))
+        (array/new-filled (max ;(keys m)))
         (pairs m)))))
 
 (defn- diff-associative-key [a b k]
@@ -58,8 +55,8 @@
 
 (defn- diff-sequential [a b]
   (map vectorize (diff-associative
-                   (if (array? a) a (arr a))
-                   (if (array? b) b (arr b))
+                   (if (array? a) a (array ;a))
+                   (if (array? b) b (array ;b))
                    (range (max (length a) (length b))))))
 
 (defn- diff-similar [kind a b]
@@ -81,7 +78,7 @@
   ```
   [a b]
   (if (= a b)
-    @[nil nil (cond (tuple? a) (apply array a)
+    @[nil nil (cond (tuple? a) (array ;a)
                 (struct? a) (struct/to-table a) a)]
     (if (= (categorize a) (categorize b))
       (diff-similar (type a) a b)

--- a/spork/data.janet
+++ b/spork/data.janet
@@ -1,0 +1,153 @@
+###
+### data.janet 
+###
+### Compare data structures using `diff`.
+###
+
+(varfn diff [])
+
+(defn- atom-diff
+  [a b]
+  (if (= a b) @[nil nil a] @[a b nil]))
+
+(defn- in? [x ds]
+  (if (index-of x ds)
+    true
+    false))
+
+(defn- safe-in [ds n]
+  (if (in? (type ds) [:array :tuple])
+    (if (<= n (dec (length ds)))
+      (in ds n)
+      nil)
+    (in ds n)))
+
+(comment 
+  (def ds a))
+
+(defn- arr [a]
+  (apply array a))
+
+(defn- vectorize [m]
+  (unless (or (nil? m) (empty? m))
+          (when (in? (type m) [:array :tuple :table :struct])
+            (reduce
+             (fn [result [k v]] (put result k v))
+             (array/new-filled (apply max (keys m)))
+             (pairs m)))))
+
+(comment 
+  (def m @{2 3}))
+
+(defn- diff-associative-key [a b k]
+  (let [va (safe-in a k)
+        vb (safe-in b k)
+        [a* b* ab] (diff va vb)
+        in-a (in? k (keys a))
+        in-b (in? k (keys b))
+        same (and in-a in-b
+                  (or (not (nil? ab))
+                      (and (nil? va) (nil? vb))))]
+    [(when (and in-a (or (not (nil? a*)) (not same))) {k a*})
+     (when (and in-b (or (not (nil? b*)) (not same))) {k b*})
+     (when same {k ab})
+     ]))
+
+(comment 
+  (def diff1 (diff-associative-key a b :a))
+  (def diff2 (diff-associative-key a b :b))
+  (def diff2 (diff-associative-key a b :c))
+  
+  (def k 2))
+
+(defn- diff-associative [a b ks]
+  (reduce 
+   (fn [diff1 diff2]
+     (map | (if (empty? $) nil $)
+          (map | (merge (or $0 {}) (or $1 {})) diff1 diff2)))
+   [nil nil nil]
+   (map
+    (partial diff-associative-key a b)
+    ks)))
+
+(defn- diff-sequential [a b]
+  (map vectorize (diff-associative
+                  (if (array? a) a (arr a))
+                  (if (array? b) b (arr b))
+                  (range (max (length a) (length b))))))
+
+(defn- diff-similar [kind a b]
+  (cond 
+    (in? kind [:array :tuple]) (diff-sequential a b)
+    (in? kind [:table :struct]) (diff-associative a b (distinct (array/concat (keys a) (keys b))))
+    (atom-diff a b)))
+
+(defn- categorize [x]
+  (cond 
+    (in? (type x) [:array :tuple]) :sequence
+    (in? (type x) [:table :struct]) :associative
+    :atom))
+
+(varfn diff 
+  ``` 
+  Compares a and b recursively. Returns an array of 
+  [things-only-in-a things-only-in-b things-in-both].   
+  ```
+  [a b]
+  (if (= a b)
+    @[nil nil (cond (tuple? a) (apply array a) 
+                    (struct? a) (struct/to-table a) a)]
+    (if (= (categorize a) (categorize b))
+      (diff-similar (type a) a b)
+      (atom-diff a b))))
+
+(comment
+  (def a {:a 1 :b 2})
+
+  (def b {:a 1 :b 3})
+
+  (def kind (type a))
+
+  (def ks (distinct (array/concat (keys a) (keys b))))
+
+  (def k (in ks 1))
+  )
+
+(comment
+  (def a 2)
+
+  (def b 3)
+
+  (def kind (type a))
+
+  (def ks (distinct (array/concat (keys a) (keys b))))
+
+  (def k (in ks 1))
+  )
+
+(comment
+  (def a [1 2])
+
+  (def b [1 2 3])
+
+  (def kind (type a))
+
+  (def ks (distinct (array/concat (keys a) (keys b))))
+
+  (def k (in ks 1))
+  )
+
+(comment
+  (def a {:map1 {:a 1 :b 2} :map2 {:c 3 :d 4}})
+
+  (def b {:map1 {:a 1 :b 2} :map2 {:c 3 :d 5}})
+
+  (def kind (type a))
+
+  (def ks (distinct (array/concat (keys a) (keys b))))
+
+  (def k (in ks 1))
+  )
+
+(comment 
+  (diff a b))

--- a/test/suite0021.janet
+++ b/test/suite0021.janet
@@ -53,6 +53,6 @@
    [@[1 2 3] [1 2 3] @[nil nil @[1 2 3]] "Should be: Array and Tuple, same"]
    [@[1 2 3] [1 2 3 4 5] @[nil @[nil nil nil 4 5] @[1 2 3]] "Should be: Array and Tuple, different"]])
 
-(map |(apply diff-assert $) cases)
+(map |(diff-assert ;$) cases)
 
 (end-suite)

--- a/test/suite0021.janet
+++ b/test/suite0021.janet
@@ -1,0 +1,52 @@
+(use ../spork/test)
+(import ../spork/data :as d)
+
+(start-suite 21)
+
+(assert-docs "/spork/data")
+
+(defn diff-assert [a b should-be msg]
+  (assert (deep= (d/diff a b) should-be) msg))
+
+(def cases
+  [[1 1 @[nil nil 1] "Should be: Integers, same"]
+   [1 2 @[1 2 nil] "Should be: Integers, different"]
+   
+   ["1" "1" @[nil nil "1"] "Should be: Strings, same"]
+   ["1" "2" @["1" "2" nil] "Should be: Strings, different"]
+
+   ["String" 1 @["String" 1 nil] "Should be: String and Integer, different"]
+
+   [[1 2 3] [1 2 3] @[nil nil @[1 2 3]] "Should be: Tuples, same"]
+   [[1 2 3] [1 2 3 4] @[nil @[nil nil nil 4] @[1 2 3]] "Should be: Tuples, element added"]
+   [[1 2 3] [1 2] @[@[nil nil 3] nil @[1 2]] "Should be: Tuples, element removed"]
+   [[1 2 3] [1 5 3] @[@[nil 2] @[nil 5] @[1 nil 3]] "Should be: Tuples, element changed"]
+   [[1 2 3] [1 5] @[@[nil 2 3] @[nil 5] @[1]] "Should be: Tuples, element changed and element removed"]
+
+   [@[1 2 3] @[1 2 3] @[nil nil @[1 2 3]] "Should be: Arrays, same"]
+   [@[1 2 3] @[1 2 3 4] @[nil @[nil nil nil 4] @[1 2 3]] "Should be: Arrays, element added"]
+   [@[1 2 3] @[1 2] @[@[nil nil 3] nil @[1 2]] "Should be: Arrays, element removed"]
+   [@[1 2 3] @[1 5 3] @[@[nil 2] @[nil 5] @[1 nil 3]] "Should be: Arrays, element changed"]
+   [@[1 2 3] @[1 5] @[@[nil 2 3] @[nil 5] @[1]] "Should be: Arrays, element changed and element removed"]
+
+   [{:a 1 :b 2} {:a 1 :b 2} @[nil nil @{:a 1 :b 2}] "Should be: Structs, same"]
+   [{:a 1 :b 2} {:a 1 :b 2 :c 3} @[nil @{:c 3} @{:a 1 :b 2}] "Should be: Structs, element added"]
+   [{:a 1 :b 2} {:a 1} @[@{:b 2} nil @{:a 1}] "Should be: Structs, element removed"]
+   [{:a 1 :b 2} {:a 1 :b 5} @[@{:b 2} @{:b 5} @{:a 1}] "Should be: Structs, element changed"]
+   [{:a 1 :b 2} {:b 5} @[@{:a 1 :b 2} @{:b 5} nil] "Should be: Structs, element changed and element removed"]
+
+   [@{:a 1 :b 2} @{:a 1 :b 2} @[nil nil @{:a 1 :b 2}] "Should be: Tables, same"]
+   [@{:a 1 :b 2} @{:a 1 :b 2 :c 3} @[nil @{:c 3} @{:a 1 :b 2}] "Should be: Tables, element added"]
+   [@{:a 1 :b 2} @{:a 1} @[@{:b 2} nil @{:a 1}] "Should be: Tables, element removed"]
+   [@{:a 1 :b 2} @{:a 1 :b 5} @[@{:b 2} @{:b 5} @{:a 1}] "Should be: Tables, element changed"]
+   [@{:a 1 :b 2} @{:b 5} @[@{:a 1 :b 2} @{:b 5} nil] "Should be: Tables, element changed and element removed"]
+   
+   [{:a 1 :b 2} @{:a 1 :b 2} @[nil nil @{:a 1 :b 2}] "Should be: Struct and Table, same"]
+   [{:a 1 :b 2} @{:a 1 :b 2 :c 4 :d 5} @[nil @{:c 4 :d 5} @{:a 1 :b 2}] "Should be: Struct and Table, different"]
+   
+   [@[1 2 3] [1 2 3] @[nil nil @[1 2 3]] "Should be: Array and Tuple, same"]
+   [@[1 2 3] [1 2 3 4 5] @[nil @[nil nil nil 4 5] @[1 2 3]] "Should be: Array and Tuple, different"]])
+
+(map |(apply diff-assert $) cases)
+
+(end-suite)

--- a/test/suite0021.janet
+++ b/test/suite0021.janet
@@ -11,7 +11,7 @@
 (def cases
   [[1 1 @[nil nil 1] "Should be: Integers, same"]
    [1 2 @[1 2 nil] "Should be: Integers, different"]
-   
+
    ["1" "1" @[nil nil "1"] "Should be: Strings, same"]
    ["1" "2" @["1" "2" nil] "Should be: Strings, different"]
 
@@ -46,10 +46,10 @@
    [@{:a 1 :b {:c 1 :d 2}} @{:a 1 :b {:c 1}} @[@{:b @{:d 2}} nil @{:a 1 :b @{:c 1}}] "Should be: Nested Tables, element removed"]
    [@{:a 1 :b {:c 1 :d 2}} @{:a 1 :b {:c 1 :d 5}} @[@{:b @{:d 2}} @{:b @{:d 5}} @{:a 1 :b @{:c 1}}] "Should be: Nested Tables, element changed"]
    [@{:a 1 :b {:c 1 :d 2}} @{:b {:c 1 :d 5}} @[@{:a 1 :b @{:d 2}} @{:b @{:d 5}} @{:b @{:c 1}}] "Should be: Nested Tables, element changed and element removed"]
-   
+
    [{:a 1 :b 2} @{:a 1 :b 2} @[nil nil @{:a 1 :b 2}] "Should be: Struct and Table, same"]
    [{:a 1 :b 2} @{:a 1 :b 2 :c 4 :d 5} @[nil @{:c 4 :d 5} @{:a 1 :b 2}] "Should be: Struct and Table, different"]
-   
+
    [@[1 2 3] [1 2 3] @[nil nil @[1 2 3]] "Should be: Array and Tuple, same"]
    [@[1 2 3] [1 2 3 4 5] @[nil @[nil nil nil 4 5] @[1 2 3]] "Should be: Array and Tuple, different"]])
 

--- a/test/suite0021.janet
+++ b/test/suite0021.janet
@@ -40,6 +40,12 @@
    [@{:a 1 :b 2} @{:a 1} @[@{:b 2} nil @{:a 1}] "Should be: Tables, element removed"]
    [@{:a 1 :b 2} @{:a 1 :b 5} @[@{:b 2} @{:b 5} @{:a 1}] "Should be: Tables, element changed"]
    [@{:a 1 :b 2} @{:b 5} @[@{:a 1 :b 2} @{:b 5} nil] "Should be: Tables, element changed and element removed"]
+
+   [@{:a 1 :b {:c 1 :d 2}} @{:a 1 :b {:c 1 :d 2}} @[nil nil @{:a 1 :b @{:c 1 :d 2}}] "Should be: Nested Tables, same"]
+   [@{:a 1 :b {:c 1 :d 2}} @{:a 1 :b {:c 1 :d 2 :e {:f 1 :g 2}} :h 3} @[nil @{:b @{:e {:f 1 :g 2}} :h 3} @{:a 1 :b @{:c 1 :d 2}}] "Should be: Nested Tables, element added"]
+   [@{:a 1 :b {:c 1 :d 2}} @{:a 1 :b {:c 1}} @[@{:b @{:d 2}} nil @{:a 1 :b @{:c 1}}] "Should be: Nested Tables, element removed"]
+   [@{:a 1 :b {:c 1 :d 2}} @{:a 1 :b {:c 1 :d 5}} @[@{:b @{:d 2}} @{:b @{:d 5}} @{:a 1 :b @{:c 1}}] "Should be: Nested Tables, element changed"]
+   [@{:a 1 :b {:c 1 :d 2}} @{:b {:c 1 :d 5}} @[@{:a 1 :b @{:d 2}} @{:b @{:d 5}} @{:b @{:c 1}}] "Should be: Nested Tables, element changed and element removed"]
    
    [{:a 1 :b 2} @{:a 1 :b 2} @[nil nil @{:a 1 :b 2}] "Should be: Struct and Table, same"]
    [{:a 1 :b 2} @{:a 1 :b 2 :c 4 :d 5} @[nil @{:c 4 :d 5} @{:a 1 :b 2}] "Should be: Struct and Table, different"]


### PR DESCRIPTION
Clojure contains a very useful core library called [clojure.data](https://github.com/clojure/clojure/blob/51c6d7a70912a8f65e81a8e11ae6f56c94920725/src/clj/clojure/data.clj). It contains one "exported" function: `clojure.data/diff`.

The `diff` function recursively compares the structure and contents of two data structures (list, vector, set, map) and returns a Clojure tuple with three elements:

`[things-only-in-a things-only-in-b things-in-both]`

In the case of nested maps, the comparison is recursive and the data structures are neatly partitioned into the same `[things-only-in-a things-only-in-b things-in-both]` structure, but arbitrary levels deep in the two compared Clojure maps. 

So for example, diff'ing the two Clojure maps `{:a 1 :b 2 :c {:d 3 :e 4}}` and `{:a 4 :b 2 :c {:d 3 :e 5 :f 6}}` returns `({:c {:e 4}, :a 1} {:c {:e 5, :f 6}, :a 4} {:c {:d 3}, :b 2})`. This is because: 
- the value for `:a` appears in both and is different in each one (so `:a` is a key in both the first and second map, with each value set as seen in the first and second original maps)
- the value for `:b` appears in both and is the same in each (so `:b` is a key only in the third map, containing the shared value in both original maps)
- the nested value of `:d` appears in both and is the same in each (so `:c` is a key in the third map, containing the value of `:d` that is shared in both original maps)
- the nested value of `:e` appears in both and is different in each one (so `:c` is a key in both the first and second map, containing the value `:e` with with each value set as seen in the first and second original maps), and
- the key/value pair `:f 6` only appears in the latter map (so only the second map contains `:f` and its value).

This function makes comparing two Clojure maps for changes trivial. (An example use case: compare the decoded JSON returned from a REST API call made seconds ago against the version of that same decoded JSON from that same API that was returned from the same call made an hour ago and stored locally in a database for comparison an hour later.)

This addition to spork, `data.janet`, should exactly replicate the behavior of `clojure.data/diff` using Janet tables, structs, arrays, and tuples in place of their Clojure equivalents.