### PR TITLE
Fix mdz build for syntax highliting

### DIFF
--- a/doc/misc.mdz
+++ b/doc/misc.mdz
@@ -126,7 +126,7 @@ pairs arguments and setting its prototype to prototype.
 Factory function for creating new objects from prototypes.
 
 @codeblock[janet]```
-(def Proto @{:greet |(string "Hello " ($ :name))})
+(def Proto @{:greet (fn [self] (string "Hello " (self :name)))})
 (def t (misc/make Proto :name "pepe"))
 (:greet t)
 # => "Hello pepe"

--- a/doc/temple.mdz
+++ b/doc/temple.mdz
@@ -22,7 +22,7 @@ output.
 
 ### foo.temple
 
-@codeblock[janet]```
+@codeblock```
 {$ (def n 20) # Run at template compile time $}
 <html>
   <body>


### PR DESCRIPTION
Both anonymous function and HTML declared as Janet are giving problems to Mendoza.

Fixes #86 