### PR TITLE
Fix panic arg in `raw_term.c:extract_codepoint`

### DIFF
--- a/src/rawterm.c
+++ b/src/rawterm.c
@@ -342,7 +342,7 @@ static uint32_t extract_codepoint(const uint8_t **pstr, const uint8_t *end) {
     *pstr = str;
     return codepoint;
 exit:
-    janet_panics("invalid codepoint");
+    janet_panic("invalid codepoint");
 }
 
 /* Measure the size of a single character in a monospaced terminal */


### PR DESCRIPTION
I got the following error in clang:
```
src/rawterm.c:345:18: warning: passing 'char[18]' to parameter of type 'JanetString' (aka 'const unsigned char *') converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
    janet_panics("invalid codepoint");
                 ^~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/janet/1.25.1/include/janet/janet.h:1957:57: note: passing argument to parameter 'message' here
JANET_NO_RETURN JANET_API void janet_panics(JanetString message);
                                                        ^
```

This change should fix the error and avoid undefined behavior. 
