### PR TITLE
added sh/exec-slurp-all

### DIFF
--- a/spork/sh.janet
+++ b/spork/sh.janet
@@ -21,6 +21,24 @@
      (:wait proc))
    (string/trimr buf))
 
+(defn exec-slurp-all
+   `Read stdout and stderr of subprocess and return it trimmed in a struct with :err and :out containing the output as string.
+   This will also return the exit code under the :status key.`
+   [& args]
+   (def proc (os/spawn args :p {:out :pipe :err :pipe}))
+   (def out (get proc :out))
+   (def err (get proc :err))
+   (def out-buf @"")
+   (def err-buf @"")
+   (var status 0)
+   (ev/gather
+     (:read out :all out-buf)
+     (:read err :all err-buf)
+     (set status (:wait proc)))
+   {:err (string/trimr err-buf)
+    :out (string/trimr out-buf)
+    :status status})
+
 (defn rm
   "Remove a directory and all sub directories recursively."
   [path]


### PR DESCRIPTION
I added sh/exec-slurp-all 
It has a similar behavior to sh/exec-slurp, but also collects stderr.
It also doesn't throw an error on a failed command, but returns the exit code.