### PR TITLE
Reset passed and run tests on start-suite

### DIFF
--- a/spork/test.janet
+++ b/spork/test.janet
@@ -38,7 +38,9 @@
   [&opt name]
   (default name (dyn :current-file))
   (set suite-num name)
-  (set start-time (os/clock)))
+  (set start-time (os/clock))
+  (set num-tests-passed 0)
+  (set num-tests-run 0))
 
 (defn end-suite
   "Ends test suite, prints summary and exits if any have failed."


### PR DESCRIPTION
With the current state, the number of tests for suites in one file accumulates, which is not ideal. And if I got it wrong, then feel free to close this.