### PR TITLE
:pointer case didnt work:

### DIFF
--- a/spork/cjanet.janet
+++ b/spork/cjanet.janet
@@ -462,10 +462,15 @@
 
 (defn- emit-function
   [docstring classes name arglist rtype body]
+  (def rettype (if (= :tuple (type rtype))
+                 (if (= "*" (string (first rtype)))
+                   (string ;(reverse rtype))
+                   (string (first rtype) " " ;(reverse (last rtype))))
+                 rtype))
   (print)
   (emit-comment docstring)
   (emit-storage-classes classes)
-  (prin rtype " " name "(")
+  (prin rettype " " name "(")
   (var is-first true)
   (each arg arglist
     (unless is-first (prin ", "))


### PR DESCRIPTION
it printed "<tuple 0x023B4A2F7E40>" instead of "void*" with rtype being tuple: (* void)

now it prints type* in that case, so void*
or JanetBuffer* in case of :buffer ...
or const char* in case of cstring