### PR TITLE
i is incremented on encountering any of & &opt

### DIFF
--- a/spork/cjanet.janet
+++ b/spork/cjanet.janet
@@ -727,8 +727,8 @@
         (array/push
           argument-parsing
           (if found-optional
-            (janet-opt* p 'argv 'argc i param-names cparams)
-            (janet-get* p 'argv i param-names cparams)))))
+            (janet-opt* p 'argv 'argc (length argument-parsing) param-names cparams)
+            (janet-get* p 'argv (length argument-parsing) param-names cparams)))))
     (buffer/format signature " %j" p))
   (def opt-index (index-of '&opt params))
   (def amp-index (index-of '& params))


### PR DESCRIPTION
&key etc. but length of paramlist only on found params


without this, optional parameter get-calls use wrong index:

```
 (c/cfunction create-window
               :static
     ""
     [width:int
      height:int
      title:cstring
      &opt
      (monitor (* GLFWmonitor) NULL)
      (share (* GLFWwindow) NULL)] -> :pointer
```
gives:
```
...
const char * title = janet_getcstring(argv, 2);
void *monitor = janet_optabstract(argv, argc, 4, GLFWmonitor, NULL);
...
```

expected a 3 in that last line