### PR TITLE
emit-declaration: when called by emit-statement, there is a semi in caller emit-block

### DIFF
--- a/spork/cjanet.janet
+++ b/spork/cjanet.janet
@@ -332,11 +332,9 @@
   [binding &opt value]
   (def [v vtype] (type-split binding))
   (emit-type vtype v)
-  (if (not= nil value)
-    (do
-      (prin " = ")
-      (emit-expression value true))
-    (print ";")))
+  (when (not= nil value)
+    (prin " = ")
+    (emit-expression value true)))
 
 (varfn emit-statement
   [form]

--- a/spork/cjanet.janet
+++ b/spork/cjanet.janet
@@ -504,7 +504,8 @@
   (def v (last form))
   (when (next storage-classes)
     (emit-storage-classes storage-classes))
-  (emit-declaration binding v))
+  (emit-declaration binding v)
+  (print ";"))
 
 (defn- do-typedef
   [n d]


### PR DESCRIPTION
i feel if this breaks do-declare, it should be fixed in do-declare... like adding a (print ";") there, but emit-statement is only called by emit-block which already emits a semicolon