### PR TITLE
fixed bug in sh/copy and added sh/exec and sh/exec-fail

### DIFF
--- a/spork/sh.janet
+++ b/spork/sh.janet
@@ -120,7 +120,7 @@
   Expects input to be unix style paths`
   [src dest]
   (print "copying " src " to " dest "...")
-  (if (= (= :windows (os/which)))
+  (if (= :windows (os/which))
     (let [end (last (path/posix/parts src))
           isdir (= (os/stat src :mode) :directory)]
       (os/shell (string "C:\\Windows\\System32\\xcopy.exe"

--- a/spork/sh.janet
+++ b/spork/sh.janet
@@ -10,8 +10,18 @@
   []
   (os/open (if (= :windows (os/which)) "NUL" "/dev/null") :rw))
 
+(defn exec
+  "Execute command specified by args returning it's exit code"
+  [& args]
+  (os/execute args :p))
+
+(defn exec-fail
+  "Execute command specified by args, fails when command exits with non-zero exit code"
+  [& args]
+  (os/execute args :px))
+
 (defn exec-slurp
-   "Read stdout of subprocess and return it trimmed in a string."
+   "Read stdout of command specified by args and return it trimmed in a string."
    [& args]
    (def proc (os/spawn args :px {:out :pipe}))
    (def out (get proc :out))


### PR DESCRIPTION
If we have exec-slurp it makes sense to also have a simple exec in sh in my book.
Also fixed a bug in sh/copy