### PR TITLE
Added shell like string splitting to spork/sh

### DIFF
--- a/spork/sh.janet
+++ b/spork/sh.janet
@@ -158,7 +158,7 @@
   "Split a string into 'sh like' tokens, returns
    nil if unable to parse the string."
   [s]
-  (peg/match peg s))
+  (peg/match shlex-grammar s))
 
 (defn- quote1
   [arg]

--- a/spork/sh.janet
+++ b/spork/sh.janet
@@ -142,3 +142,36 @@
                         "/e "
                         "/i ")))
     (os/execute ["cp" "-rf" src dest] :p)))
+
+(def- shlex-grammar (peg/compile ~{
+  :ws (set " \t\r\n")
+  :escape (* "\\" (capture 1))
+  :dq-string (accumulate (* "\"" (any (+ :escape (if-not "\"" (capture 1)))) "\""))
+  :sq-string (accumulate (* "'" (any (if-not "'" (capture 1))) "'"))
+  :token-char (+ :escape (* (not :ws) (capture 1)))
+  :token (accumulate (some :token-char))
+  :value (* (any (+ :ws)) (+ :dq-string :sq-string :token) (any :ws))
+  :main (any :value)
+}))
+
+(defn split
+  "Split a string into 'sh like' tokens, returns
+   nil if unable to parse the string."
+  [s]
+  (peg/match peg s))
+
+(defn- quote1
+  [arg]
+  (def buf (buffer/new (* (length arg) 2)))
+  (buffer/push-string buf "'")
+  (each c arg
+    (if (= c (chr "'"))
+      (buffer/push-string buf "'\\''")
+      (buffer/push-byte buf c)))
+  (buffer/push-string buf "'")
+  (string buf))
+
+(defn quote
+  "Output a string with all arguments correctly quoted"
+  [& args]
+  (string/join (map quote1 args) " "))

--- a/spork/sh.janet
+++ b/spork/sh.janet
@@ -160,7 +160,7 @@
   [s]
   (peg/match shlex-grammar s))
 
-(defn- quote1
+(defn- shell-quote
   [arg]
   (def buf (buffer/new (* (length arg) 2)))
   (buffer/push-string buf "'")
@@ -171,7 +171,7 @@
   (buffer/push-string buf "'")
   (string buf))
 
-(defn quote
+(defn escape
   "Output a string with all arguments correctly quoted"
   [& args]
-  (string/join (map quote1 args) " "))
+  (string/join (map shell-quote args) " "))

--- a/test/suite0017.janet
+++ b/test/suite0017.janet
@@ -35,4 +35,8 @@
              nil)
           "sh/rm didn't work correctly"))
 
+(assert (deep= 
+          (sh/split ` "c d \" f" ' y z'  a b a\ b --cflags `)
+          @["c d \" f" " y z" "a" "b" "a b" "--cflags"]))
+
 (end-suite)


### PR DESCRIPTION
I imported the code from andrewchamber's [janet-shlex](https://github.com/andrewchambers/janet-shlex) (with permission).
It allows splitting a string following shell quoting rules.