### PR TITLE
Add fmt configuration

### DIFF
--- a/bin/janet-format
+++ b/bin/janet-format
@@ -3,6 +3,8 @@
 (import spork/fmt)
 (import spork/argparse)
 
+(def- default-config ".janet-format.jdn")
+
 (defn- main
   [&]
 
@@ -27,10 +29,29 @@
     "input"
     {:short "i"
      :kind :option
-     :help "Read from an input file"}))
+     :help "Read from an input file"}
+
+    "config"
+    {:short "c"
+     :kind :option
+     :help "Which configuration file to read"
+     :default default-config}
+
+    "no-config"
+    {:short "n"
+     :kind :flag
+     :help "Avoid loading any configuration"}))
 
   # Break on help text
   (unless ap (break))
+
+  (unless (ap "no-config")
+    (def config (ap "config"))
+    (def [exists contents] (protect (slurp config)))
+    (if exists
+      (setdyn fmt/*user-indent-2-forms* (parse contents))
+      (when (not= config default-config)
+        (eprintf "Configuration file '%s' does not exist" config))))
 
   (if (or (ap "files") (ap :default))
     (each file (ap :default)

--- a/bin/janet-format
+++ b/bin/janet-format
@@ -9,38 +9,38 @@
   [&]
 
   (def ap
-   (argparse/argparse
-    "Format Janet source code in files and write output to those files."
+    (argparse/argparse
+      "Format Janet source code in files and write output to those files."
 
-    :default
-    {:kind :accumulate
-     :help "Files to format"}
+      :default
+      {:kind :accumulate
+       :help "Files to format"}
 
-    "files"
-    {:short "f"
-     :help "Format a list of source files."
-     :kind :flag}
+      "files"
+      {:short "f"
+       :help "Format a list of source files."
+       :kind :flag}
 
-    "output"
-    {:short "o"
-     :kind :option
-     :help "Where to direct output to. By default, output goes to stdout."}
+      "output"
+      {:short "o"
+       :kind :option
+       :help "Where to direct output to. By default, output goes to stdout."}
 
-    "input"
-    {:short "i"
-     :kind :option
-     :help "Read from an input file"}
+      "input"
+      {:short "i"
+       :kind :option
+       :help "Read from an input file"}
 
-    "config"
-    {:short "c"
-     :kind :option
-     :help "Which configuration file to read"
-     :default default-config}
+      "config"
+      {:short "c"
+       :kind :option
+       :help "Which configuration file to read"
+       :default default-config}
 
-    "no-config"
-    {:short "n"
-     :kind :flag
-     :help "Avoid loading any configuration"}))
+      "no-config"
+      {:short "n"
+       :kind :flag
+       :help "Avoid loading any configuration"}))
 
   # Break on help text
   (unless ap (break))

--- a/spork/fmt.janet
+++ b/spork/fmt.janet
@@ -143,7 +143,7 @@
     [xs]
     (emit "(")
     (def len (length xs))
-    (when (pos? len) 
+    (when (pos? len)
       (fmt-1-recur (xs 0))
       (indent 1)
       (for i 1 len (fmt-1-recur (xs i)))

--- a/spork/fmt.janet
+++ b/spork/fmt.janet
@@ -77,6 +77,11 @@
       node)
     node))
 
+(defdyn *user-indent-2-forms*
+  "A user list of forms that are control forms and should be indented two spaces.")
+
+(defn- user-indent-2-forms [] (invert (or (dyn *user-indent-2-forms*) [])))
+
 (def- indent-2-forms
   "A list of forms that are control forms and should be indented two spaces."
   (invert ["fn" "match" "with" "with-dyns" "def" "def-" "var" "var-" "defn" "defn-"
@@ -99,7 +104,8 @@
       (= "\n" (get items 1)) true
       (not= tag :span) nil
       (in indent-2-forms body) true
-      (peg/match indent-2-peg body) true)))
+      (peg/match indent-2-peg body) true
+      (in (user-indent-2-forms) body) true)))
 
 (defn- fmt
   "Emit formatted."


### PR DESCRIPTION
This is a configuration that will be helpful for DSLs, there's already one used in `project.janet` that uses `phony` and friends. There's a peg `(peg/compile ~(+ "with-" "def" "if-" "when-")` that tries to solve this problem but it is not enough in some situations. The current version is an initial draft, other improvements that may follow:
- More configuration options, but I can't think of any.
- More intelligent discovery of the configuration file, for example when inside a project tree, the search could be traversed to every parent directory until the `project.janet` file is found, then it stops.

Example config file .janet-config.jdn
```
["phony"]
```

I formatted the files I touched in a separate commit, I hope it's alright, let me know if not.

The configuration option probably needs a description but I'm unsure where to put the documentation for it. It should either be:
1. Transform the configuration file into a map, then the map key could be `:user-indent-2-forms` so it gives some context to the user.
2. Embed the documentation into the help message from argparse, so there's less incentive to expand the list of possible options.

Example before/after:

```
(phony "server" []
       (os/shell "janet main.janet"))

(phony "server" []
  (os/shell "janet main.janet"))
```