### PR TITLE
fixed misc/map-keys handling of array values

### DIFF
--- a/spork/misc.janet
+++ b/spork/misc.janet
@@ -223,16 +223,17 @@
      (,xprintf ,to ,;args)))
 
 (defn map-keys
-  ```
+   ```
   Returns new table with function `f` applied to `data`'s
   keys recursively.
   ```
   [f data]
-  (-> (seq [[k v] :pairs data]
-        [(f k) (if (dictionary? v) (map-keys f v) v)])
-      flatten
-      splice
-      table))
+  (def res @{})
+  (loop [[k v] :pairs data]
+    (put res (f k)
+         (if (dictionary? v)
+           (map-keys f v) v)))
+  res)
 
 (defn map-vals
   "Returns new table with function `f` applied to `data`'s values."


### PR DESCRIPTION
`misc/map-keys` was broken for cases like `(misc/map-keys |(string $0) {:test [1 2 3]})` in which it produced `@{2 3 "test" 1}` or even failed with inputs like `{:test [1 2 3 4]}`.
This should fix that by ensuring values are always left as is. I also disabled the default recursion as I think that is quite an unexpected behavior, but I left a flag to enable recursion.
This changes the function signature of misc/map-keys, but I think no one uses this function, as anyone having a value with an array in it would discover this bug pretty fast.
As this was merged from pepe's marble into spork: have a ping: @pepe 