### PR TITLE
don't print colored output in test when not (os/isatty)

### DIFF
--- a/spork/test.janet
+++ b/spork/test.janet
@@ -18,7 +18,9 @@
      (def ,xx ,x)
      (if ,xx (++ (',tests-passed-ref 0)))
      (as-macro ,unless ,xx
-       (,prin "\e[31m✘\e[0m  ")
+       (if (os/isatty)
+        (,prin "\e[31m✘\e[0m  ")
+        (,prin "[FAIL] "))
        (,print ,e))
      ,xx))
 


### PR DESCRIPTION
Does exactly what the title says.
I originally wanted to expand `spork/test` a bit here too, but decided to split this first simple one.
Should be easier to discuss.