### PR TITLE
added misc/map-keys-flat to map keys without recursing

### DIFF
--- a/spork/misc.janet
+++ b/spork/misc.janet
@@ -234,6 +234,17 @@
       splice
       table))
 
+(defn map-keys-flat
+   ```
+  Returns new table with function `f` applied to `data`'s
+  keys without recursing.
+  ```
+  [f data]
+  (def res @{})
+  (loop [[k v] :pairs data]
+    (put res (f k) v))
+  res)
+
 (defn map-vals
   "Returns new table with function `f` applied to `data`'s values."
   [f data]

--- a/spork/misc.janet
+++ b/spork/misc.janet
@@ -240,10 +240,8 @@
   keys without recursing.
   ```
   [f data]
-  (def res @{})
-  (loop [[k v] :pairs data]
-    (put res (f k) v))
-  res)
+  (tabseq [[k v] :pairs data]
+    (f k) v))
 
 (defn map-vals
   "Returns new table with function `f` applied to `data`'s values."

--- a/test/suite0020.janet
+++ b/test/suite0020.janet
@@ -47,6 +47,14 @@
   "map-keys in nested struct")
 
 (assert
+  (deep= (misc/map-keys-flat string {1 [1 2 3] 3 [1 2]}) @{"1" [1 2 3] "3" [1 2]})
+  "map-keys-flat in dictionary")
+(assert
+  (deep= (misc/map-keys-flat string {1 2 3 {:a :b :c {:d 3}}})
+         @{"1" 2 "3" {:a :b :c {:d 3}}})
+  "map-keys-flat in nested struct")
+
+(assert
   (deep= (misc/map-vals string {1 2 3 4}) @{1 "2" 3 "4"})
   "map-vals of the dictionary 1")
 (assert


### PR DESCRIPTION
As discussed in https://github.com/janet-lang/spork/pull/136 here's map-keys-flat in it's own PR.