### PR TITLE
Update `generators/to-array`

### DIFF
--- a/spork/generators.janet
+++ b/spork/generators.janet
@@ -18,7 +18,7 @@
 (defn to-array
   "Consume `s` into a new array."
   [s]
-  (values s))
+  (seq [v :in s] v))
 
 (defn run
   "Evaluate `s` for side effects."

--- a/test/suite0011.janet
+++ b/test/suite0011.janet
@@ -11,65 +11,65 @@
 
 (def s (generators/from-iterable [1 2 3]))
 (generator-assert! s)
-(assert (deep= @[1 2 3] (values s)))
+(assert (deep= @[1 2 3] (generators/to-array s)))
 
 (def s (generators/from-iterable @[1 2 3]))
 (generator-assert! s)
-(assert (deep= @[1 2 3] (values s)))
+(assert (deep= @[1 2 3] (generators/to-array s)))
 
 (def s (generators/from-iterable @[1 2 3]))
 (def s2 (generators/from-iterable s))
 (generator-assert! s)
-(assert (deep= @[1 2 3] (values s2)))
+(assert (deep= @[1 2 3] (generators/to-array s2)))
 
 (def s (generators/range 1 10))
 (generator-assert! s)
-(assert (deep= @[1 2 3 4 5 6 7 8 9] (values s)))
+(assert (deep= @[1 2 3 4 5 6 7 8 9] (generators/to-array s)))
 
 (def s (generators/concat [1] @[2] (generators/from-iterable [3 4 5])))
 (generator-assert! s)
-(assert (deep= @[1 2 3 4 5] (values s)))
+(assert (deep= @[1 2 3 4 5] (generators/to-array s)))
 
 (def s (generators/map inc [1 2 3]))
 (generator-assert! s)
-(assert (deep= @[2 3 4] (values s)))
+(assert (deep= @[2 3 4] (generators/to-array s)))
 
 (def s (generators/filter odd? [1 2 3]))
 (generator-assert! s)
-(assert (deep= @[1 3] (values s)))
+(assert (deep= @[1 3] (generators/to-array s)))
 
 (def s (generators/take 2 [1 2 3]))
 (generator-assert! s)
-(assert (deep= @[1 2] (values s)))
+(assert (deep= @[1 2] (generators/to-array s)))
 
 (def s (generators/take-while odd? [1 2 3]))
 (generator-assert! s)
-(assert (deep= @[1] (values s)))
+(assert (deep= @[1] (generators/to-array s)))
 
 (def s (generators/take-until even? [1 2 3]))
 (generator-assert! s)
-(assert (deep= @[1] (values s)))
+(assert (deep= @[1] (generators/to-array s)))
 
 (def s (generators/drop 1 [1 2 3]))
 (generator-assert! s)
-(assert (deep= @[2 3] (values s)))
+(assert (deep= @[2 3] (generators/to-array s)))
 
 (def s (generators/drop-while odd? [1 2 3]))
 (generator-assert! s)
-(assert (deep= @[2 3] (values s)))
+(assert (deep= @[2 3] (generators/to-array s)))
 
 (def s (generators/drop-until even? [1 2 3]))
 (generator-assert! s)
-(assert (deep= @[2 3] (values s)))
+(assert (deep= @[2 3] (generators/to-array s)))
 
 (def s (generators/cycle [1 2 3]))
 (generator-assert! s)
 (def taken (generators/take 10 s))
-(assert (deep= @[1 2 3 1 2 3 1 2 3 1] (values taken)))
+(assert (deep= @[1 2 3 1 2 3 1 2 3 1] (generators/to-array taken)))
 
 (def s (generators/cycle {:a 1 :b 2 :c 3}))
 (def taken (generators/take 10 s))
-(def taken-array (values taken))
+(def taken-array (generators/to-array taken))
 (assert  (= 10 (length taken-array)))
 (assert (deep= @[1 2 3] (sorted (distinct taken-array))))
 


### PR DESCRIPTION
Update `generators/to-array` to consume its argument into an array, as documented.