### PR TITLE
create a table instead of an array to hold the fibers in pmap-full

### DIFF
--- a/spork/ev-utils.janet
+++ b/spork/ev-utils.janet
@@ -82,8 +82,9 @@
   (def chan (ev/chan))
   (def res (if (dictionary? data) @{} @[]))
   (join chan
-        (seq [[i x] :pairs data]
-          (ev/go (fiber/new (fn [] (put res i (f x))) :tp) nil chan)))
+        (tabseq [[i x] :pairs data
+                 :let [fib (ev/go (fiber/new (fn [] (put res i (f x))) :tp) nil chan)]]
+          fib fib))
   res)
 
 (defn pmap-limited


### PR DESCRIPTION
There is a crash when using pmap-full because the list of fibers passed to "join" is an array and not a table.
The fix aligns pmap-full implementation to pcall.
```
error: bad slot #0, expected table, got <array 0x600002C65C40>
  in table/clear [src/core/table.c] on line 411
  in drain-fibers [/Users/mraveloarinjaka/projects/sandbox/aoc2023/jpm_tree/lib/spork/ev-utils.janet] on line 35, column 3
  in join [/Users/mraveloarinjaka/projects/sandbox/aoc2023/jpm_tree/lib/spork/ev-utils.janet] on line 56, column 10
  in pmap-full [/Users/mraveloarinjaka/projects/sandbox/aoc2023/jpm_tree/lib/spork/ev-utils.janet] (tailcall) on line 84, column 3
```
