### PR TITLE
Feature: Add a Gaussian sampler

### DIFF
--- a/spork/randgen.janet
+++ b/spork/randgen.janet
@@ -37,9 +37,7 @@
 
 (defn rand-gaussian
   "Get a random sample from the standard Gaussian distribution. 
-  Optionall specify the mean m and the standard deviation sd. E.g.:
-  (rand-gaussian) # => 0.1324...
-  (rand-gaussian 5 0.1) # => 5.3397...
+  Optionall specify the mean m and the standard deviation sd. 
   "
   [&opt m sd]
   (default m 0)
@@ -52,8 +50,10 @@
   # We use the Box-Muller transform
   (let [rho (math/sqrt (* -2 (math/log q)))
         theta (* 2 math/pi p)
-        # _box (* rho (math/cos theta))
         _muller (* rho (math/sin theta))
+        # in devices where hardware entropy pool usage should be efficient
+        # we can achieve x2 efficiency by using the `box` variable as well
+        # _box (* rho (math/cos theta))
         # box (scale _box)
         muller (scale _muller)]
 
@@ -61,11 +61,7 @@
     muller))
 
 (defn sample-n
-  "Generate n samples based on the random sampler f. E.g.
-  (sample-n |(rand-int 0 3) 4) # => @[0 1 2 0]
-  (sample-n |(rand-uniform) 4)
-  (sample-n |(rand-gaussian 5 0.1) 4)
-  "
+  "Generate n samples based on the random sampler `f`."
   [f n]
   (take n (generate [_ :iterate true]
             (f))))

--- a/spork/randgen.janet
+++ b/spork/randgen.janet
@@ -28,6 +28,41 @@
   (def diff (- end start))
   (+ start (math/floor (* diff (rand-uniform)))))
 
+(defn rand-gaussian
+  "Get a random sample from the standard Gaussian distribution. 
+  Optionall specify the mean m and the standard deviation sd. E.g.:
+  (rand-gaussian) # => 0.1324...
+  (rand-gaussian 5 0.1) # => 5.3397...
+  "
+  [&opt m sd]
+  (default m 0)
+  (default sd 1)
+  (defn scale [x] (+ m (* sd x)))
+
+  (def p (math/rng-uniform (get-rng)))
+  (def q (math/rng-uniform (get-rng)))
+
+  # We use the Box-Muller transform
+  (let [rho (math/sqrt (* -2 (math/log q)))
+        theta (* 2 math/pi p)
+        # _box (* rho (math/cos theta))
+        _muller (* rho (math/sin theta))
+        # box (scale _box)
+        muller (scale _muller)]
+
+    # (yield box)
+    muller))
+
+(defn sample-n
+  "Generate n samples based on the random sampler f. E.g.
+  (sample-n |(rand-int 0 3) 4) # => @[0 1 2 0]
+  (sample-n |(rand-uniform) 4)
+  (sample-n |(rand-gaussian 5 0.1) 4)
+  "
+  [f n]
+  (take n (generate [_ :iterate true]
+            (f))))
+
 (defn rand-index
   "Get a random numeric index of an indexed data structure"
   [xs]
@@ -85,4 +120,3 @@
   [weights & paths]
   ~(case (,rand-weights ,weights)
      ,;(array/concat @[] ;(map tuple (range (length paths)) paths))))
-

--- a/spork/randgen.janet
+++ b/spork/randgen.janet
@@ -57,7 +57,6 @@
         # box (scale _box)
         muller (scale _muller)]
 
-    # (yield box)
     muller))
 
 (defn sample-n

--- a/test/suite-randgen.janet
+++ b/test/suite-randgen.janet
@@ -1,0 +1,24 @@
+(use ../spork/test)
+(use ../spork/randgen)
+
+(start-suite)
+
+(assert-docs "/spork/randgen")
+
+(def delta 0.0000000000001)
+
+(assert (do
+          (set-seed 1)
+          (def expected @[5.0318756480189 5.10069692026214 4.89567968233822 4.95051117259612])
+          (def actual
+           (sample-n |(rand-gaussian 5 0.1) 4))
+          (and (all |(> delta (math/abs (- $0 $1)))
+                    expected actual)))
+        "sample-rand-gaussian")
+
+(assert (do 
+          (set-seed 1)
+          (def expected 0.318756480188982) 
+          (def actual (rand-gaussian)) 
+          (|(> delta (math/abs (- $0 $1))) expected actual)
+          "call-rand-gaussian"))


### PR DESCRIPTION
This adds a Gaussian sampler that exposes a similar interface to `spork/rand-uniform`, that is:
- can be called without args `(rand-gaussian)` for a single standard Gaussian sample
- can be called with args `(rand-gaussian 5 0.1)` for a single Gaussian sample with specified parameters
- can be used to generate `N` samples with the `sample-n` function, using `(sample-n |(rand-gaussian 5 0.1) 100)`
- does not leave any state pending (no fiber used) at the expense of wasting half the entropy exracted from the RNG device (does janet runtime rely on OS RNG entropy pool?)