### PR TITLE
Fix `spork/stream/lines`. Refine `spork/stream` functions.

### DIFF
--- a/spork/stream.janet
+++ b/spork/stream.janet
@@ -36,9 +36,10 @@
   * end of stream is reached.
   * stream or channel is closed.
 
-  This function ignores errors from closed streams and closed channels.
+  If `supervisor` is a channel, the channel is used as the supervisor channel. If `supervisor` is nil or not specified,
+  the task inherits the current supervisor channel.
   ```
-  [stream &opt separator]
+  [stream &named separator supervisor]
   (def fiber (lines stream separator))
   (def ch (ev/chan))
   (defn give-lines
@@ -46,10 +47,7 @@
     (when-let [line (resume fiber)]
       (ev/give ch line)
       (give-lines)))
-  (ev/spawn
-    (try
-      (defer (:close ch)
-        (give-lines))
-      # Ignore errors caused by closed streams and closed channels.
-      ([_])))
+  (ev/go |(defer (:close ch)
+            (give-lines))
+         nil supervisor)
   ch)

--- a/spork/stream.janet
+++ b/spork/stream.janet
@@ -7,10 +7,7 @@
   (default separator "\n")
   (defn yield-lines
     [chunk]
-    # if-let breaks tail call optimization. when-let depends on if-let.
-    # https://github.com/janet-lang/janet/issues/1401
-    (def idx (string/find "\n" chunk))
-    (when idx
+    (when-let [idx (string/find separator chunk)]
       # Yield the first line
       (yield (buffer/slice chunk 0 idx))
       # Eliminate the first line from chunk without creating a new buffer
@@ -46,13 +43,9 @@
   (def ch (ev/chan))
   (defn give-lines
     []
-    # if-let breaks tail call optimization. when-let depends on if-let.
-    # https://github.com/janet-lang/janet/issues/1401
-    (def line (resume fiber))
-    (when line
-      (do
-        (ev/give ch line)
-        (give-lines))))
+    (when-let [line (resume fiber)]
+      (ev/give ch line)
+      (give-lines)))
   (ev/spawn
     (try
       (defer (:close ch)

--- a/spork/stream.janet
+++ b/spork/stream.janet
@@ -1,9 +1,10 @@
 (defn lines
   ```
   Returns a fiber that yields each line from a core/stream value. If separator is not specified, the default separator
-  is `\n`. If the stream is closed before the fiber yields all lines, an error is thrown from the stream.
+  is `\n`. After the fiber yields the last line, it returns `nil`. If the fiber is resumed after the stream is closed or
+  after the fiber returns `nil`, an error is thrown.
   ```
-  [stream &opt separator]
+  [stream &named separator]
   (default separator "\n")
   (defn yield-lines
     [chunk]
@@ -30,17 +31,13 @@
   ```
   Returns a channel that gives each line from a core/stream value. An asynchronous task feeds lines to the channel. If
   separator is not specified, the default separator is `\n`. To make sure that the task is finished, drain all lines
-  from the channel, or close the stream and the channel. Otherwise, the task remains frozen in the background. The
-  channel gives `nil` after one of those conditions applies.
-
-  * end of stream is reached.
-  * stream or channel is closed.
-
-  If `supervisor` is a channel, the channel is used as the supervisor channel. If `supervisor` is nil or not specified,
-  the task inherits the current supervisor channel.
+  from the channel, or close the stream and the channel. Otherwise, the task remains frozen in the background. After the
+  channel gives the last line, the channel is closed. After stream or channel is closed, the channel gives `nil`. If
+  `supervisor` is a channel, the channel is used as the supervisor channel. If `supervisor` is nil or not specified, the
+  task inherits the current supervisor channel.
   ```
   [stream &named separator supervisor]
-  (def fiber (lines stream separator))
+  (def fiber (lines stream :separator separator))
   (def ch (ev/chan))
   (defn give-lines
     []

--- a/spork/stream.janet
+++ b/spork/stream.janet
@@ -29,21 +29,35 @@
 
 (defn lines-channel
   ```
-  Returns a channel that gives each line from a core/stream value. An asynchronous task feeds lines to the channel. If
-  separator is not specified, the default separator is `\n`. To make sure that the task is finished, drain all lines
-  from the channel, or close the stream and the channel. Otherwise, the task remains frozen in the background. After the
-  channel gives the last line, the channel is closed. After stream or channel is closed, the channel gives `nil`. If
-  `supervisor` is a channel, the channel is used as the supervisor channel. If `supervisor` is nil or not specified, the
-  task inherits the current supervisor channel.
+  Returns a channel that gives each line from a core/stream value. If separator is not specified, the default separator
+  is `\n`. `supervisor` argument is passed to `ev/go` which launches two tasks that feed lines to the channel. To finish
+  the tasks, drain all lines from the channel, or close the channel. Otherwise, the tasks remain frozen. When the tasks
+  finish, the channel is closed. A stream error finishes the tasks with an error. Writing to the channel finishes the
+  tasks with an error or freezes the fiber that tries to write to the channel.
   ```
   [stream &named separator supervisor]
-  (def fiber (lines stream :separator separator))
   (def ch (ev/chan))
-  (defn give-lines
-    []
-    (when-let [line (resume fiber)]
-      (ev/give ch line)
-      (give-lines)))
+  (def stream-ch (ev/chan))
+  (def stream-task (ev/go |(try
+                             (defer (:close stream-ch)
+                               (each line (lines stream :separator separator)
+                                 (ev/give stream-ch line)))
+                             ([err f]
+                               (unless (= err :cancel)
+                                 (propagate err f))))
+                          nil supervisor))
+  (defn give-lines []
+    (match (ev/select ch stream-ch)
+      [:take c line]
+      (if (= c stream-ch)
+        (do
+          (ev/give ch line)
+          (give-lines))
+        (error "Writing to the returned channel is prohibited."))
+      [:close c]
+      # If stream-ch is closed, give-lines exits quietly.
+      (when (= c ch)
+        (ev/cancel stream-task :cancel))))
   (ev/go |(defer (:close ch)
             (give-lines))
          nil supervisor)


### PR DESCRIPTION
* `spork/stream/lines` ignored separator argument. Now, it is respected.
* `separator` argument in `spork/stream/lines` is now a named argument.
* minor issues with docstring in `spork/stream` functions are fixed.
* supervisor argument is added to `spork/stream/lines-channel`. The supervisor channel is notified of stream errors.
* closing the channel returned by `spork/stream/lines-channel` finishes the tasks that feed the channel.