### PR TITLE
CI/CD feature: Remove "This workflow requires approval from a maintainer"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
     branches: [ master ]
 
 jobs:


### PR DESCRIPTION
Removes friction from PR contributions and automatically triggers the linters/checks without first getting "approval" from repo maintainer.