### PR TITLE
Change arg name for sextets->octets

### DIFF
--- a/spork/base64.janet
+++ b/spork/base64.janet
@@ -51,8 +51,8 @@
        (map |(array ;$0))))
 
 (defn- sextets->octets
-  [octets]
-  (->> octets
+  [sextets]
+  (->> sextets
        flatten
        (partition 8)))
 


### PR DESCRIPTION
This PR contains a suggestion to change the current argument name for the `sextets->octets` function in `base64.janet`.