### PR TITLE
Fix compilation on macOS

### DIFF
--- a/spork/cc.janet
+++ b/spork/cc.janet
@@ -154,11 +154,13 @@
   (def dflt (index-of (target-os) [:linux]))
   (dyn *smart-libs* dflt))
 (defn- libs []
+  (def dl (if (= (target-os) :macos) ["-undefined" "dynamic_lookup"] []))
   (def sg (if (smart-libs) ["-Wl,--start-group"] []))
   (def eg (if (smart-libs) ["-Wl,--end-group"] []))
   (def bs (if (not= (target-os) :macos) ["-Wl,-Bstatic"] []))
   (def bd (if (not= (target-os) :macos) ["-Wl,-Bdynamic"] []))
   [;(lflags)
+   ;dl
    ;sg
    ;(default-libs)
    ;bs

--- a/spork/cc.janet
+++ b/spork/cc.janet
@@ -147,20 +147,24 @@
 (defn- rpath
   []
   (if (dyn *use-rpath* true)
-    [(string "-Wl,-rpath=" (lib-path))
-     (string "-Wl,-rpath=" (dyn *syspath* "."))]
+    [(string "-Wl,-rpath," (lib-path))
+     (string "-Wl,-rpath," (dyn *syspath* "."))]
     []))
 (defn- smart-libs []
-  (def dflt (index-of (target-os) [:linux :macos]))
+  (def dflt (index-of (target-os) [:linux]))
   (dyn *smart-libs* dflt))
 (defn- libs []
   (def sg (if (smart-libs) ["-Wl,--start-group"] []))
   (def eg (if (smart-libs) ["-Wl,--end-group"] []))
+  (def bs (if (not= (target-os) :macos) ["-Wl,-Bstatic"] []))
+  (def bd (if (not= (target-os) :macos) ["-Wl,-Bdynamic"] []))
   [;(lflags)
    ;sg
    ;(default-libs)
-   "-Wl,-Bstatic" ;(static-libs)
-   "-Wl,-Bdynamic" ;(dynamic-libs)
+   ;bs
+   ;(static-libs)
+   ;bd
+   ;(dynamic-libs)
    ;eg
    ;(rpath)])
 (defn- rdynamic


### PR DESCRIPTION
As discussed in #191, `cc.janet` does not work correctly when compiling on macOS. This PR addresses these problems by:

1. using `-Wl,rpath,` rather than `-Wl,rpath=`
2. not using `-Wl,-Bstatic` and `-Wl,-Bdynamic` on macOS
3. disabling  `-Wl,--start-group` and `-Wl,--end-group` by default on macOS
4. enabling dynamic lookup for undefined symbols on macOS

I'm using a vendored version of this file successfully to compile Janet libraries on macOS as part of [Arnie](https://github.com/pyrmont/arnie). This fixes #191.