### PR TITLE
Define symbol early enough for use in math

### DIFF
--- a/spork/math.janet
+++ b/spork/math.janet
@@ -357,9 +357,10 @@
         (+= sy y)
         (+= sxx (* x x))
         (+= sxy (* x y)))
-      {:m (def m
-            (/ (- (* cl sxy) (* sx sy))
-               (- (* cl sxx) (* sx sx))))
+      (def m
+        (/ (- (* cl sxy) (* sx sy))
+           (- (* cl sxx) (* sx sx))))
+      {:m m
        :b (- (/ sy cl) (/ (* m sx) cl))})))
 
 (defn linear-regression-line


### PR DESCRIPTION
There was [a CI error related to #203](https://github.com/janet-lang/spork/actions/runs/12004487043/job/33459550150?pr=203).

My current guess is that due to [recent changes in hashing in janet](https://github.com/janet-lang/janet/issues/1520), the order in which the key-value pairs are evaluated has changed.

So before may be: https://github.com/janet-lang/spork/blob/44e26016352a66fd49470eb2170aa111d887484b/spork/math.janet#L360-L363

worked fine because luckily the `(def m ...)` happened before the use of `m` for the value associated with `:b`.

This PR just moves the `def` form out of the struct.