### PR TITLE
Remove unused def

### DIFF
--- a/spork/netrepl.janet
+++ b/spork/netrepl.janet
@@ -242,7 +242,7 @@
                (if auto-flush
                  (do
                    (set keep-flushing true)
-                   (def f (go-nursery nurse flusher))
+                   (go-nursery nurse flusher)
                    (edefer (set keep-flushing false)
                      (def result (x))
                      (set keep-flushing false)


### PR DESCRIPTION
Currently, [the following exists in netrepl.janet](https://github.com/janet-lang/spork/blob/deda9658e84477be3b4fa33150f7c9e282a1e3bd/spork/netrepl.janet#L245):

```janet
(def f (go-nursery nurse flusher))
```

It looks like it may be safe to replace it with:

```janet
(go-nursery nurse flusher)
```

as there are no other relevant references to `f`.

This PR is a suggestion to make that replacement.

---

It appears `(def f ...)` was needed at some point before, but when [this change](https://github.com/janet-lang/spork/commit/a3d9d1ba67abb9af28081b437e385ab079ec11cc#diff-6325e8f118a5017cf80fa18326395289464d772b47c88b045cd2d8f960f49727R240) was made (may need to scroll up depending on browser settings), the code:

```janet
(edefer (ev/cancel f "form evaluated")
```

was replaced with:

```janet
(edefer (set keep-flushing false)
```

It seems that the last bit of code that needed to refer to `f` was removed in that change.