### PR TITLE
Tweak markup to address #206

### DIFF
--- a/doc/api/generators.mdz
+++ b/doc/api/generators.mdz
@@ -4,7 +4,7 @@
  :template "mdzdoc/main.html"}
 ---
 
-A @strong[generator] is an iterable data structure which yields individual values whenever called, potentially until its internal values are exhausted, at which point it's considered @i[dead].
+A @strong[generator] is an iterable data structure which yields individual values whenever called, potentially until its internal values are exhausted, at which point it's considered @em[dead].
 
 This operation makes them very useful for:
 


### PR DESCRIPTION
This PR contains a change to the markup in [doc/api/generators.mdz](https://github.com/janet-lang/spork/blob/7fd743ac09e857fe0ebd333bd7a56cd0df3876c3/doc/api/generators.mdz) as an attempt to address #206.

It's a simple substitution of `em` for `i`.