### PR TITLE
Tweak some import and assert-docs paths

### DIFF
--- a/test/suite-declare-cc.janet
+++ b/test/suite-declare-cc.janet
@@ -1,8 +1,8 @@
 (use ../spork/test)
-(import spork/declare-cc)
+(import ../spork/declare-cc)
 
 (start-suite)
 
-(assert-docs "spork/declare-cc")
+(assert-docs "/spork/declare-cc")
 
 (end-suite)

--- a/test/suite-pm.janet
+++ b/test/suite-pm.janet
@@ -6,7 +6,7 @@
 (start-suite)
 
 (assert true) # smoke test
-(assert-docs "spork/pm")
+(assert-docs "/spork/pm")
 
 # Copy since not exposed in boot.janet
 (defn- bundle-rpath

--- a/test/suite-pmfull.janet
+++ b/test/suite-pmfull.janet
@@ -20,7 +20,7 @@
 (unless enabled (print "set SPORK_TEST_ALL_PACKAGES=1 to run full pm testing."))
 (when enabled
   (assert true) # smoke test
-  (assert-docs "spork/pm")
+  (assert-docs "/spork/pm")
   (math/seedrandom (os/cryptorand 16))
   (def syspath (randdir))
   (sh/rm syspath)


### PR DESCRIPTION
This PR is a suggestion to modify some paths in a few `import` and `assert-docs` calls.

The background is that in 2d4638cf, running some of the test files gives errors like:

```
$ janet test/suite-pm.janet 
error: could not find module spork/pm:
    /home/user/.local/lib/janet/spork/pm.jimage
    /home/user/.local/lib/janet/spork/pm.janet
    /home/user/.local/lib/janet/spork/pm/init.janet
    /home/user/.local/lib/janet/spork/pm.so
  in require-1 [boot.janet] (tail call) on line 3125, column 20
  in assert-docs [spork/test.janet] on line 149, column 27
  in thunk [test/suite-pm.janet] (tail call) on line 9, column 1
```

```
$ SPORK_TEST_ALL_PACKAGES=1 janet test/suite-pmfull.janet 
error: could not find module spork/pm:
    /home/user/.local/lib/janet/spork/pm.jimage
    /home/user/.local/lib/janet/spork/pm.janet
    /home/user/.local/lib/janet/spork/pm/init.janet
    /home/user/.local/lib/janet/spork/pm.so
  in require-1 [boot.janet] (tail call) on line 3125, column 20
  in assert-docs [spork/test.janet] on line 149, column 27
  in thunk [test/suite-pmfull.janet] (tail call) on line 23, column 3
```

```
$ janet test/suite-declare-cc.janet 
error: could not find module spork/declare-cc:
    /home/user/.local/lib/janet/spork/declare-cc.jimage
    /home/user/.local/lib/janet/spork/declare-cc.janet
    /home/user/.local/lib/janet/spork/declare-cc/init.janet
    /home/user/.local/lib/janet/spork/declare-cc.so
  in require-1 [boot.janet] on line 3125, column 20
  in import* [boot.janet] on line 3169, column 15
  in thunk [test/suite-declare-cc.janet] (tail call) on line 2, column 1
```