### PR TITLE
cc/pkg-config: handle tuple *cflags* and *ldflags*

### DIFF
--- a/spork/cc.janet
+++ b/spork/cc.janet
@@ -746,8 +746,8 @@
   (def leftovers (search-libraries ;libs))
   (unless (empty? leftovers)
     (errorf "could not find libraries %j" leftovers))
-  (array/concat (getsetdyn *cflags*) cflags)
-  (array/concat (getsetdyn *lflags*) lflags)
+  (array/concat @[] (getsetdyn *cflags*) cflags)
+  (array/concat @[] (getsetdyn *lflags*) lflags)
   nil)
 
 ###


### PR DESCRIPTION
Currently using :pkg-config-libs with declare-executable gives the following error:

error: bad slot #0, expected array, got <tuple 0x7C2127E0CE00>
  in array/concat [src/core/array.c] on line 250
  in pkg-config [/home/ifreund/.local/lib/janet/spork/cc.janet] (tail call) on line 749, column 3
  in target [/home/ifreund/.local/lib/janet/spork/declare-cc.janet] on line 828, column 11
  in edefer [/home/ifreund/.local/lib/janet/spork/build-rules.janet] on line 118, column 22
  in _while [/home/ifreund/.local/lib/janet/spork/build-rules.janet] on line 112, column 7
  in worker [/home/ifreund/.local/lib/janet/spork/build-rules.janet] on line 105, column 5
  in defer [/home/ifreund/.local/lib/janet/spork/build-rules.janet] on line 19, column 11
  in wait-for-fibers [/home/ifreund/.local/lib/janet/spork/build-rules.janet] on line 12, column 3
  in run-rules [/home/ifreund/.local/lib/janet/spork/build-rules.janet] (tail call) on line 132, column 3
  in run-main [boot.janet] on line 4523, column 16
  in cli-main [boot.janet] on line 4745, column 17

We could try to ensure that *cflags*/*ldflags* are always an array, but simply guarding against the chance that they could be a tuple in cc/pkg-config seems more robust.