### PR TITLE
Brief: Fix smart-libs when executable depends on native module.

### DIFF
--- a/spork/cc.janet
+++ b/spork/cc.janet
@@ -223,10 +223,10 @@
   (def eg (if (smart-libs) ["-Wl,--end-group"] []))
   (def bs (if (not= (target-os) :macos) ["-Wl,-Bstatic"] []))
   (def bd (if (not= (target-os) :macos) ["-Wl,-Bdynamic"] []))
-  [;(lflags)
+  [;sg
+   ;(lflags)
    ;(if static ["-static"] [])
    ;dl
-   ;sg
    ;(default-libs)
    ;bs
    ;(static-libs)


### PR DESCRIPTION
Summary: If a native executable depends on a module that includes native code, and that module could also depend on a static library, then all the extra libs added from that module (via the `foo.meta.janet` file) need to be included in the same --start-group/--end-group along with janet.a and the native code from the executable.

in this link line, from my re-janet library, you can see the linker adding "-lpcre2-8" that comes from the `jre.meta.janet` file. But is is before the `--start-group` and therefore causes missing symbols on Linux.

```
g++ -std=c++11 -O2 -g -I/home/bob/dev/janet/include -L/home/bob/dev/janet/lib/janet -L/home/bob/dev/janet/lib -o _build/release/jgrep ./_build___release___jgrep.c.o -rdynamic -pthread -L/home/bob/dev/janet/lib/janet/jre -lpcre2-8 -Wl,--start-group -lm -lrt -ldl -Wl,-Bstatic /home/bob/dev/janet/lib/libjanet.a /home/bob/dev/janet/lib/janet/spork/cmath.a /home/bob/dev/janet/lib/janet/spork/tarray.a /home/bob/dev/janet/lib/janet/spork/zip.a /home/bob/dev/janet/lib/janet/spork/json.a /home/bob/dev/janet/lib/janet/jre/native.a /home/bob/dev/janet/lib/janet/spork/utf8.a /home/bob/dev/janet/lib/janet/spork/rawterm.a _build/release/jgutils___native.a /home/bob/dev/janet/lib/janet/spork/crc.a /home/bob/dev/janet/lib/janet/spork/base64.a -Wl,-Bdynamic -Wl,--end-group -Wl,-rpath,/home/bob/dev/janet/lib -Wl,-rpath,/home/bob/dev/janet/lib/janet
/usr/bin/ld: /home/bob/dev/janet/lib/janet/jre/native.a(cpp___module.cpp.static.o): in function `(anonymous namespace)::pcre2_set_gc(void*, unsigned long)':
module.cpp:(.text+0xe0e): undefined reference to `pcre2_code_free_8'
/usr/bin/ld: /home/bob/dev/janet/lib/janet/jre/native.a(cpp___module.cpp.static.o): in function `(anonymous namespace)::new_abstract_pcre2_regex(char const*, Janet const*, int, int)':
module.cpp:(.text+0x21a2): undefined reference to `pcre2_compile_8'
/usr/bin/ld: module.cpp:(.text+0x221d): undefined reference to `pcre2_jit_compile_8'
/usr/bin/ld: module.cpp:(.text+0x229d): undefined reference to `pcre2_get_error_message_8'
```

with this change, you can see the successful link, with the `--start-group` before the `-lpcre2-8`

```
gcc -std=c99 -O2 -g -I/home/bob/dev/janet/include -I/home/bob/dev/janet/lib/janet -I/home/bob/dev/janet/include -fPIC -DJANET_BUILD_TYPE=develop -c _build/release/jgrep.c -o ./_build___release___jgrep.c.o -pthread
g++ -std=c++11 -O2 -g -I/home/bob/dev/janet/include -L/home/bob/dev/janet/lib/janet -L/home/bob/dev/janet/lib -o _build/release/jgrep ./_build___release___jgrep.c.o -rdynamic -pthread -Wl,--start-group -L/home/bob/dev/janet/lib/janet/jre -lpcre2-8 -lm -lrt -ldl -Wl,-Bstatic /home/bob/dev/janet/lib/libjanet.a /home/bob/dev/janet/lib/janet/spork/cmath.a /home/bob/dev/janet/lib/janet/spork/tarray.a /home/bob/dev/janet/lib/janet/spork/zip.a /home/bob/dev/janet/lib/janet/spork/json.a /home/bob/dev/janet/lib/janet/jre/native.a /home/bob/dev/janet/lib/janet/spork/utf8.a /home/bob/dev/janet/lib/janet/spork/rawterm.a _build/release/jgutils___native.a /home/bob/dev/janet/lib/janet/spork/crc.a /home/bob/dev/janet/lib/janet/spork/base64.a -Wl,-Bdynamic -Wl,--end-group -Wl,-rpath,/home/bob/dev/janet/lib -Wl,-rpath,/home/bob/dev/janet/lib/janet
```