### PR TITLE
Fix PATH separator in ps activate script

### DIFF
--- a/spork/pm.janet
+++ b/spork/pm.janet
@@ -698,7 +698,7 @@
   $$global:_OLD_JANET_PATH=$$env:JANET_PATH
   $$global:_OLD_PATH=$$env:PATH
   $$env:JANET_PATH="$abspath"
-  $$env:PATH=$$env:JANET_PATH + "\bin:" + $$env:PATH
+  $$env:PATH=$$env:JANET_PATH + "\bin;" + $$env:PATH
   $$function:old_prompt = $$function:prompt
   function global:prompt {
     Write-Host "($name) " -NoNewline


### PR DESCRIPTION
Another POSIX muscle memory catch. I am enjoying the usage of special environments a lot!