### PR TITLE
Remove unused code

### DIFF
--- a/spork/declare-cc.janet
+++ b/spork/declare-cc.janet
@@ -400,7 +400,6 @@
       (def second-line (string/format "(put root-env :original-syspath (os/realpath (dyn *syspath*))) # auto generated\n"))
       (def third-line (string/format "(put root-env :syspath %v) # auto generated\n" (dyn *syspath*)))
       (def fourth-line (string/format "(put root-env :install-time-syspath %v) # auto generated\n" (dyn *syspath*)))
-      (def last-line "\n(put root-env :syspath (get root-env :original-syspath)) # auto generated\n")
       (def rest (:read f :all))
       (string (if auto-shebang (string "#!/usr/bin/env janet\n"))
               first-line


### PR DESCRIPTION
This PR is a follow-up to the discussion starting [here](https://github.com/janet-lang/spork/pull/230#issuecomment-3334372279).

As part of #230, the lone use of `last-line` was removed from the definition of `declare-binscript`.  This PR is a suggestion to remove the definition of `last-line` since it does not appear to be used any more.