### PR TITLE
Brief: Restore code that cleans dynamic syspath at the end of binscript

### DIFF
--- a/spork/declare-cc.janet
+++ b/spork/declare-cc.janet
@@ -400,13 +400,15 @@
       (def second-line (string/format "(put root-env :original-syspath (os/realpath (dyn *syspath*))) # auto generated\n"))
       (def third-line (string/format "(put root-env :syspath %v) # auto generated\n" (dyn *syspath*)))
       (def fourth-line (string/format "(put root-env :install-time-syspath %v) # auto generated\n" (dyn *syspath*)))
+      (def last-line "\n(put root-env :syspath (get root-env :original-syspath)) # auto generated\n")
       (def rest (:read f :all))
       (string (if auto-shebang (string "#!/usr/bin/env janet\n"))
               first-line
               (if (or dynamic-syspath hardcode-syspath) second-line)
               (if hardcode-syspath third-line)
               (if hardcode-syspath fourth-line)
-              rest)))
+              rest
+              (if dynamic-syspath last-line))))
   (install-buffer contents dest 8r755 (mkbin))
   (when (is-win-or-mingw)
     (def absdest (path/join (dyn *syspath*) dest))

--- a/test/suite-pm-pre-post.janet
+++ b/test/suite-pm-pre-post.janet
@@ -75,14 +75,15 @@
        (pm/pm-install "file::.")
        (assert (= 1 (length (bundle/list))) "bundle/list after install")
 
+       # invoking janet-pm via the shell needs JANET_PATH set to
+       # know about our custom syspath
+       (os/setenv "JANET_PATH" (dyn *syspath*))
+
        # make sure the right janet-pm is found and
-       # verify all bin scripts have two copies of hard-coded syspath, one in body
-       # and one in main
        (def binpath (path/join (dyn *syspath*) "bin"))
        (def janet-pm (path/join binpath (string "janet-pm")))
        (assert (sh/exists? janet-pm))
        (dump-out (sh/exec-slurp-all (string janet-pm bat) "show-config"))
-       (assert (= 1 (length (string/find-all "put root-env :install-time-syspath" (slurp janet-pm)))))
 
        # check sub commands work, even without defining pre-/post-
 


### PR DESCRIPTION
Summary: In a previous PR #230,  in an attempt to get tests working where packages were being installed into the original syspath instead of a test-local syspath, I removed some code that "fixed" the test but broke binscripts more generally.

binscripts are set up with a dynamic syspath hardcoded at the beginning and removed at the end to make sure they can find their dependencies, regardless of JANET_PATH.

This restores that behavior. The tests were originally failing since they were running `janet-pm` via `sh/exec` AND `janet-pm` didn't know about the custom JANET_PATH.

So the second change here, just to the tests, is to set JANET_PATH to the test-local syspath before running `janet-pm` via `sh/exec`

This should also address the problem seen in #248, where `janet-pm` fails after activating a new `env`