### PR TITLE
Apply :has-bin-script less widely

### DIFF
--- a/spork/declare-cc.janet
+++ b/spork/declare-cc.janet
@@ -68,12 +68,14 @@
     "c++"))
 
 (defn- install-rule
-  [src dest &opt chmod-mode thunk]
+  [src dest &opt chmod-mode thunk is-exe]
   (def rules (get-rules))
   (build-rules/build-rule
     rules :install [src]
     (def manifest (assert (dyn *install-manifest*)))
-    (put manifest :has-bin-script true)
+    (when is-exe
+      (put manifest :has-bin-script true) # remove eventually
+      (put manifest :has-exe true))
     (when thunk (thunk))
     (bundle/add manifest src dest chmod-mode))
   dest)
@@ -85,7 +87,8 @@
   (build-rules/build-rule
     rules :install []
     (def manifest (assert (dyn *install-manifest*)))
-    (put manifest :has-bin-script true)
+    (put manifest :has-bin-script true) # remove eventually
+    (put manifest :has-exe true)
     (def files (get manifest :files @[]))
     (put manifest :files files)
     (def absdest (path/join (dyn *syspath*) dest))
@@ -144,8 +147,8 @@
 
 (defn install-file-rule
   "Add install and uninstall rule for moving file from src into destdir."
-  [src dest]
-  (install-rule src dest))
+  [src dest &opt chmod-mode thunk is-exe]
+  (install-rule src dest chmod-mode thunk is-exe))
 
 ###
 ### Misc. utilities
@@ -381,7 +384,7 @@
 (defn declare-bin
   "Declare a generic file to be installed as an executable."
   [&named main]
-  (install-rule main "bin" 8r755 (mkbin)))
+  (install-rule main "bin" 8r755 (mkbin) true))
 
 (defn declare-binscript
   ``Declare a janet file to be installed as an executable script. Creates
@@ -727,7 +730,7 @@ int main(int argc, const char **argv) {
   (def bd (build-dir))
   (def dest (path/join bd name))
   (def cimage-dest (string dest ".c"))
-  (when install (install-rule dest (path/join "bin" name) nil (mkbin)))
+  (when install (install-rule dest (path/join "bin" name) nil (mkbin) true))
   (def target (if no-compile cimage-dest dest))
   (rule :build [target])
   (rule target [entry ;headers ;deps]


### PR DESCRIPTION
The intent of this PR is to partially address #247.

`:has-bin-script` was being applied in too many `declare-*` constructs so this has been dialed back.

`:has-exe` has been added for the same purpose with the idea that `:has-bin-script` will be removed at some later point.  The additional  different name should help a bit with some of the points brought up in [#1648](https://github.com/janet-lang/janet/pull/1648) associated with the janet repository.

The plan is to have a companion change to janet so both janet and spork will support `:has-bin-script` and `:has-exe` for a while.

I hope some folks will try this and [the companion change](https://github.com/janet-lang/janet/pull/1658) :pray: 