### PR TITLE
`spork/test`: Fix CRLF bug in `assert-docs`

### DIFF
--- a/spork/test.janet
+++ b/spork/test.janet
@@ -152,5 +152,5 @@
                  (peg/match '(* (+ (* "(" (thru ")\n\n"))
                                    (not "("))
                                 (some 1) -1)
-                            (get val :doc "")))
+                            (string/replace-all "\r" "" (get val :doc ""))))
             (string sym " does not have proper doc"))))


### PR DESCRIPTION
Strip out `\r` from docstring before validating. Addresses #254 .