### PR TITLE
Update to macos-14 in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, macos-13 ]
+        os: [ ubuntu-latest, macos-latest, macos-14 ]
         janet-version: [ heads/master, tags/v1.38.0, tags/v1.37.1, tags/v1.36.0, tags/v1.35.2 ]
     steps:
       - name: Checkout Janet


### PR DESCRIPTION
This PR is an attempt to stop using the `macos-13` runner and use `macos-14` instead.

Please see some of the messages starting from around [here](https://github.com/janet-lang/spork/pull/256#issuecomment-3549850191) for background.