### PR TITLE
CI: Add 1.39.1 and remove 1.35.2 testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, macos-14 ]
-        janet-version: [ heads/master, tags/v1.38.0, tags/v1.37.1, tags/v1.36.0, tags/v1.35.2 ]
+        janet-version: [ heads/master, tags/v1.39.1, tags/v1.38.0, tags/v1.37.1, tags/v1.36.0 ]
     steps:
       - name: Checkout Janet
         uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-2022, windows-latest ]
-        janet-version: [ 1.35.2, 1.36.0, 1.37.1, 1.38.0 ]
+        janet-version: [ 1.36.0, 1.37.1, 1.38.0, 1.39.1 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR is an attempt to update the versions of janet that are tested against in CI.

The intent is to add testing for 1.39.1 and stop testing 1.35.2.

