### PR TITLE
getline: Add support for ctrl-u

### DIFF
--- a/spork/getline.janet
+++ b/spork/getline.janet
@@ -350,6 +350,8 @@
             (set hindex (history-move hindex 1))
             17 # ctrl-q
             (do (set more-input false) (set ret-value :cancel) (clear-lines))
+            21 # ctrl-u
+            (do (buffer/blit buf buf 0 pos) (buffer/popn buf pos) (set pos 0) (clear-lines) (refresh))
             23 # ctrl-w
             (kbackw)
             26 # ctrl-z


### PR DESCRIPTION
Don't know the original reason of not having this shortcut, but it's nice to have, isn't it?

Change-Id: I1c35f486ca5e3e1fb02a607572583a896a6a6964