### PR TITLE
getline: bugfix for <ctrl-a>

### DIFF
--- a/spork/getline.janet
+++ b/spork/getline.janet
@@ -135,7 +135,10 @@
 
     (def view (rawterm/slice-monowidth buf available-w view-pos))
     (def visual-pos (+ prpt-width (- columns-to-pos shift-right-amnt width-under-cursor)))
-    (buffer/format tmp-buf "\r%s%s%s\e[0K\r\e[%dC" prpt pad view visual-pos)
+    (buffer/format tmp-buf "\r%s%s%s\e[0K\r" prpt pad view)
+    # Different implementations may behave inconsistently regarding to "move 0 column".
+    (if (not (= 0 visual-pos))
+      (buffer/format-at tmp-buf -1 "\e[%dC"  visual-pos))
     (flushs))
 
   (defn- history-move


### PR DESCRIPTION
According to https://unix.stackexchange.com/a/559331, moving zero column is implemented inconsistently between different terminal emulators.

In order to fix this inconsistency, we avoid using this escape sequence entirely.


Change-Id: I9f6358680a6e054c2846b823af8e265c6a6a6964