### PR TITLE
netrepl: allow specifying unix socket on CLI

### DIFF
--- a/bin/janet-netrepl
+++ b/bin/janet-netrepl
@@ -26,6 +26,11 @@
      :default netrepl/default-port
      :kind :option}
 
+    "unix-socket"
+    {:short "U"
+     :help (string "Unix socket path to serve the repl at.")
+     :kind :option}
+
     "client"
     {:short "c"
      :kind :flag
@@ -63,8 +68,9 @@
 
   # Break on help text
   (unless ap (break))
-  (def host (ap "host"))
-  (def port (ap "port"))
+  (def [host port] (if-let [path (ap "unix-socket")]
+                     [:unix path]
+                     [(ap "host") (ap "port")]))
   (def dof (ap "dofile"))
   (def msg (ap "message"))
   (def msg-file (ap "message-file"))


### PR DESCRIPTION
Currently it is impossible to connect to or create a unix socket netrepl server using the janet-netrepl CLI tool. It is however easy and useful to create a unix socket based server using the (netrepl/server) function directly.

This patch adds a new --unix-socket/-U <PATH> option that overrides any host/port specified and connects to/creates a server at the given path.