### PR TITLE
pm: satisfy flycheck

### DIFF
--- a/spork/pm.janet
+++ b/spork/pm.janet
@@ -370,7 +370,7 @@
 ### Generate new projects quickly, ported from jpm
 ###
 
-(def- template-peg
+(def- template-peg :flycheck
   "Extract string pieces to generate a templating function"
   (peg/compile
     ~{:sub (group


### PR DESCRIPTION
Original issue:

```
/home/tw/code/spork > janet -k spork/pm.janet
error: spork/pm.janet:419:1: compile error: (macro) grammar error in nil, unexpected peg source
  in peg/match [src/core/peg.c] on line 1924
  in make-template [spork/pm.janet] on line 384, column 14
  in deftemplate [spork/pm.janet] on line 406, column 45
  in dofile [boot.janet] (tail call) on line 3132, column 7

```

Change-Id: I54f8c197323aa10ea6111f6eb83b86e16a6a6964