### PR TITLE
Address #284 - handle path/normalize edge case

### DIFF
--- a/spork/path.janet
+++ b/spork/path.janet
@@ -116,9 +116,11 @@
        (match x
          [:lead what] (set lead what)
          "." nil
-         ".." (if (= 0 seen)
+         ".." (if (and (nil? lead) (= 0 seen))
                 (array/push accum x)
-                (do (-- seen) (array/pop accum)))
+                (do
+                  (when (< 0 seen) (-- seen))
+                  (array/pop accum)))
          (do (++ seen) (array/push accum x))))
      (def ret (string (or lead "") (string/join accum ,sep)))
      (if (= "" ret) "." ret)))

--- a/test/suite-path.janet
+++ b/test/suite-path.janet
@@ -44,6 +44,8 @@
 # normalize
 
 (aeq (path/posix/normalize "/abc/../") "/")
+(aeq (path/posix/normalize "/abc/../../def") "/def")
+(aeq (path/posix/normalize "/../../..") "/")
 (aeq (path/posix/normalize "/abc/abc") "/abc/abc")
 (aeq (path/posix/normalize "/abc/abc/..") "/abc")
 (aeq (path/posix/normalize "/abc/abc/../") "/abc/")
@@ -53,6 +55,8 @@
 (aeq (path/posix/normalize "//////") "/")
 
 (aeq (path/win32/normalize `C:\abc\..\`) `C:\`)
+(aeq (path/win32/normalize `C:\abc\..\..\def`) `C:\def`)
+(aeq (path/win32/normalize `C:\..\..\..`) `C:\`)
 (aeq (path/win32/normalize `C:\abc\abc`) `C:\abc\abc`)
 (aeq (path/win32/normalize `C:\abc\abc\..`) `C:\abc`)
 (aeq (path/win32/normalize `C:\abc\abc\..\`) `C:\abc\`)


### PR DESCRIPTION
This PR is an attempt to address #284.

`path/normalize` builds up `accum`, a stack of path segments, which is ultimately used as part of constructing a final path.

The conditions under which `accum` is pushed to and popped from differ slightly depending on whether the original path is absolute or not.

The proposed changes attempt to distinguish the cases and act accordingly.

Also included are some regression tests for a couple of cases, expressed for the posix and win32 cases separately.