### PR TITLE
Allow empty reason phrase in http grammar, The RFC says that the Reas…

### DIFF
--- a/spork/http.janet
+++ b/spork/http.janet
@@ -15,7 +15,7 @@
 (def- http-grammar
   ~{:request-status (* :method :ws :path :ws "HTTP/1." :d :any-ws :rn)
     :response-status (* "HTTP/1." :d :ws (/ ':d+ ,scan-number)
-                        :ws '(some :printable) :rn)
+                        :ws '(any :printable) :rn)
     :ws (some (set " \t"))
     :any-ws (any (set " \t"))
     :rn "\r\n"

--- a/test/suite-http.janet
+++ b/test/suite-http.janet
@@ -35,6 +35,7 @@
 (test-http-parse http/read-request @"GET /abc.janet HTTP/1.0\r\n\r\n" "GET" "/abc.janet" nil {})
 (test-http-parse http/read-request @"GET /abc.janet HTTP/1.0\r\na:b\r\n\r\n" "GET" "/abc.janet" nil {"a" "b"})
 (test-http-parse http/read-request @"POST /abc.janet HTTP/1.0\r\na:b\r\n\r\nextraextra" "POST" "/abc.janet" nil {"a" "b"})
+(test-http-parse http/read-response @"HTTP/1.0 200 \r\na:b\r\n\r\nextraextra" nil nil 200 {"a" "b"}) # ws after 200 is required but empty Reason Phrase is allowed
 (test-http-parse http/read-response @"HTTP/1.0 200 OK\r\na:b\r\n\r\nextraextra" nil nil 200 {"a" "b"})
 (test-http-parse http/read-response @"HTTP/1.0 200 OK\r\nh:eta\r\nh:heta\r\nt:theta\r\n\r\nextraextra" nil nil 200 {"h" ["eta" "heta"] "t" "theta"})
 


### PR DESCRIPTION
Allow empty reason phrase in http grammar, The RFC says that the Reason Phrase is optional.

Refer StackOverflow https://stackoverflow.com/questions/17517086/can-an-http-response-omit-the-reason-phrase

See isse #294 