### PR TITLE
Fix typo in HTMLgen docs

### DIFF
--- a/doc/api/htmlgen.mdz
+++ b/doc/api/htmlgen.mdz
@@ -21,14 +21,14 @@ Example:
 (defn append-year [buf] (buffer/push buf (string ((os/date) :year))))
 (html
   @[[:head
-    @[[:meta {:charset "htf-8"}]
+    @[[:meta {:charset "utf-8"}]
       [:title "Spork"]]]
     [:body
       @[[:header "Menu"]
         [:main [:section "News"]]
         [:footer "All right reserved " append-year]]]])
 
-=>  @"<head><meta charset=\"htf-8\"/><title>Spork</title></head><body><header>Menu</header><main><section>News</section></main><footer>All right reserved 2022</footer></body>"
+=>  @"<head><meta charset=\"utf-8\"/><title>Spork</title></head><body><header>Menu</header><main><section>News</section></main><footer>All right reserved 2022</footer></body>"
 ```
 
 We will show how HTMLgen renders from the data structure by dissecting


### PR DESCRIPTION
In the HTMLgen example, change typo "htf-8" to "utf-8".