### PR TITLE
Print test output to stderr

### DIFF
--- a/spork/test.janet
+++ b/spork/test.janet
@@ -75,8 +75,8 @@
   "Ends test suite, prints summary and exits if any tests have failed."
   []
   (def delta (- (os/clock) start-time))
-  (prinf "test suite %V finished in %.3f seconds - " suite-num delta)
-  (print num-tests-passed " of " num-tests-run " tests passed.")
+  (eprinf "test suite %V finished in %.3f seconds - " suite-num delta)
+  (eprint num-tests-passed " of " num-tests-run " tests passed.")
   (if (not= num-tests-passed num-tests-run) (os/exit 1)))
 
 (defmacro timeit

--- a/test/suite-test.janet
+++ b/test/suite-test.janet
@@ -39,10 +39,10 @@
   (test/assert (truthy? m) "timeit2 -- invalid output")
   (test/assert (scan-number (in m 0)) "timeit2 -- invalid number of seconds"))
 
-# test/capture-stdout
+# test/capture-stderr
 (test/assert
   (= [nil "\nRunning test suite 666 tests...\n\n\e[32m\xE2\x9C\x94\e[0m\n\nTest suite 666 finished in 0.000 soconds\n13 of 13 tests passed.\n\n"])
-  (test/capture-stdout
+  (test/capture-stderr
     (test/start-suite 666)
     (test/assert true "true")
     (test/end-suite)))


### PR DESCRIPTION
## Summary

Write `spork/test` suite summaries to stderr instead of stdout and update the stream-sensitive test accordingly.

## Motivation

Assertion diagnostics already use stderr, but `end-suite` still wrote its human-facing summary to stdout. This prevented callers from reserving stdout for machine-readable subprocess protocols. In my methodology, I use stdout as the interprocess communication channel.

This change makes ordinary test reporting consistently use stderr while leaving the documented stdout behavior of `timeit` and `timeit-loop` unchanged.

## Impact

Visible test output remains the same in a terminal. Programs capturing stdout will no longer receive the final suite summary.

## Validation

- Verified `capture-stderr` receives the complete suite summary.
- Verified a representative local test process exits successfully with:
  - stdout: 0 bytes
  - stderr: the suite summary
- Rebased cleanly onto current `origin/master`.

The summary was written and revised with the help of an LLM.