### PR TITLE
Non-ASCII characters in assert text

### DIFF
--- a/spork/test.janet
+++ b/spork/test.janet
@@ -23,7 +23,10 @@
   (def line-info (string/format "%s:%d"
                                 (frame :source) (frame :source-line)))
   (if x
-    (when (is-verbose) (eprintf "\e[32m✔\e[0m %s: %s: %v" line-info (describe e) x))
+    (when (is-verbose) (eprintf "\e[32m✔\e[0m %s: %s: %v"
+                                line-info
+                                (if (string? e) e (describe e))
+                                x))
     (do
       (eprintf "\e[31m✘\e[0m %s: %s: %v" line-info (describe e) x) (eflush)))
   x)

--- a/spork/test.janet
+++ b/spork/test.janet
@@ -18,16 +18,16 @@
     (break x))
   (default e "assert error")
   (when x (++ num-tests-passed))
-  (def stack (debug/stack (fiber/current)))
-  (def frame (last stack))
-  (def line-info (string/format "%s:%d"
-                                (frame :source) (frame :source-line)))
-  (def desc (if (string? e) e (describe e)))
-
+  (defn line-data []
+    (def stack (debug/stack (fiber/current)))
+    (def frame (last stack))
+    (string/format "%s:%d: %s: %v"
+                   (frame :source) (frame :source-line)
+                   (if (string? e) e (describe e)) x))
   (if x
-    (when (is-verbose) (eprintf "\e[32m✔\e[0m %s: %s: %v" line-info desc x))
+    (when (is-verbose) (eprintf "\e[32m✔\e[0m %s" (line-data)))
     (do
-      (eprintf "\e[31m✘\e[0m %s: %s: %v" line-info desc x) (eflush)))
+      (eprintf "\e[31m✘\e[0m %s" (line-data)) (eflush)))
   x)
 
 (defn skip-asserts

--- a/spork/test.janet
+++ b/spork/test.janet
@@ -22,18 +22,12 @@
   (def frame (last stack))
   (def line-info (string/format "%s:%d"
                                 (frame :source) (frame :source-line)))
+  (def desc (if (string? e) e (describe e)))
+
   (if x
-    (when (is-verbose)
-      (eprintf "\e[32m✔\e[0m %s: %s: %v"
-               line-info
-               (if (string? e) e (describe e))
-               x))
+    (when (is-verbose) (eprintf "\e[32m✔\e[0m %s: %s: %v" line-info desc x))
     (do
-      (eprintf "\e[31m✘\e[0m %s: %s: %v"
-               line-info
-               (if (string? e) e (describe e))
-               x)
-      (eflush)))
+      (eprintf "\e[31m✘\e[0m %s: %s: %v" line-info desc x) (eflush)))
   x)
 
 (defn skip-asserts

--- a/spork/test.janet
+++ b/spork/test.janet
@@ -23,12 +23,17 @@
   (def line-info (string/format "%s:%d"
                                 (frame :source) (frame :source-line)))
   (if x
-    (when (is-verbose) (eprintf "\e[32m✔\e[0m %s: %s: %v"
-                                line-info
-                                (if (string? e) e (describe e))
-                                x))
+    (when (is-verbose)
+      (eprintf "\e[32m✔\e[0m %s: %s: %v"
+               line-info
+               (if (string? e) e (describe e))
+               x))
     (do
-      (eprintf "\e[31m✘\e[0m %s: %s: %v" line-info (describe e) x) (eflush)))
+      (eprintf "\e[31m✘\e[0m %s: %s: %v"
+               line-info
+               (if (string? e) e (describe e))
+               x)
+      (eflush)))
   x)
 
 (defn skip-asserts


### PR DESCRIPTION
## What's included

I made test library, but instead, say, `"¡Hola!"`, I see `"\xC2\xA1Hola!"` for `(assert c "¡Hola!")`.

Root cause: for string `(describe ...)` call outputs hex-encoded byte sequence, not the string itself.

## Fix
Use `(string? ...)` predicate and return string for description.