### PR TITLE
Implement `utf8/is-valid?`

### DIFF
--- a/src/utf8.c
+++ b/src/utf8.c
@@ -26,18 +26,7 @@
  * See https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt for a list
  * of test cases. */
 
-JANET_FN(cfun_utf8_decode_rune,
-        "(utf8/decode-rune buf &opt start)",
-        "Read a UTF-8 encoded Unicode codepoint from the buffer which starts at the given index. Returns a tuple [value width], where width = number of bytes consumed. If at the end of buffer or the buffer contains malformed UTF-8, returns [nil 0].") {
-    janet_arity(argc, 1, 2);
-    JanetByteView buf = janet_getbytes(argv, 0);
-    int32_t start;
-    if (argc > 1) {
-        start = janet_getinteger(argv, 1);
-    } else {
-        start = 0;
-    }
-
+static JanetTuple decode_rune(JanetByteView buf, int32_t start) {
     Janet res[2] = { janet_wrap_nil(), janet_wrap_integer(0) };
     if (start >= buf.len) {
         goto exit;
@@ -80,7 +69,22 @@ JANET_FN(cfun_utf8_decode_rune,
 
     res[1] = janet_wrap_integer(i - start);
 exit:
-    return janet_wrap_tuple(janet_tuple_n(&res[0], 2));
+    return janet_tuple_n(&res[0], 2);
+}
+
+JANET_FN(cfun_utf8_decode_rune,
+        "(utf8/decode-rune buf &opt start)",
+        "Read a UTF-8 encoded Unicode codepoint from the buffer which starts at the given index. Returns a tuple [value width], where width = number of bytes consumed. If at the end of buffer or the buffer contains malformed UTF-8, returns [nil 0].") {
+    janet_arity(argc, 1, 2);
+    JanetByteView buf = janet_getbytes(argv, 0);
+    int32_t start;
+    if (argc > 1) {
+        start = janet_getinteger(argv, 1);
+    } else {
+        start = 0;
+    }
+
+    return janet_wrap_tuple(decode_rune(buf, start));
 }
 
 JANET_FN(cfun_utf8_encode_rune,
@@ -132,11 +136,28 @@ JANET_FN(cfun_utf8_prefixtowidth,
     return janet_wrap_integer(n);
 }
 
+JANET_FN(cfun_utf8_is_valid,
+        "(utf8/is-valid? buf)",
+        "Check if a buffer contains valid UTF-8 sequences.") {
+    janet_fixarity(argc, 1);
+    JanetByteView buf = janet_getbytes(argv, 0);
+    uint32_t i = 0;
+    while (i < buf.len) {
+        JanetTuple res = decode_rune(buf, i);
+        if (janet_checktype(res[0], JANET_NIL))
+            return janet_wrap_boolean(0);
+        i += janet_unwrap_integer(res[1]);
+    }
+
+    return janet_wrap_boolean(1);
+}
+
 JANET_MODULE_ENTRY(JanetTable *env) {
     JanetRegExt cfuns[] = {
         JANET_REG("decode-rune", cfun_utf8_decode_rune),
         JANET_REG("encode-rune", cfun_utf8_encode_rune),
         JANET_REG("prefix->width", cfun_utf8_prefixtowidth),
+        JANET_REG("is-valid?", cfun_utf8_is_valid),
         JANET_REG_END
     };
     janet_cfuns_ext(env, "utf8", cfuns);

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -26,31 +26,32 @@
  * See https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt for a list
  * of test cases. */
 
-static JanetTuple decode_rune(JanetByteView buf, int32_t start) {
-    Janet res[2] = { janet_wrap_nil(), janet_wrap_integer(0) };
-    if (start >= buf.len) {
+static int32_t decode_rune(JanetByteView buf, int32_t* start) {
+    int32_t rune = -1;
+
+    if (start == NULL || *start >= buf.len) {
         goto exit;
     }
 
-    int32_t i = start;
+    int32_t i = *start;
     uint8_t a = buf.bytes[i++];
     if ((a & 0x80) == 0) {
-        res[0] = janet_wrap_integer((int32_t)a);
+        rune = (int32_t)a;
     } else if ((a & 0xE0) == 0xC0) {
         if (i >= buf.len) goto exit;
         uint8_t b = buf.bytes[i++];
         if ((b & 0xC0) != 0x80) goto exit;
-        res[0] = janet_wrap_integer((int32_t)(a & 0x1F) << 6 |
-                                    (int32_t)(b & 0x3F));
+        rune = (int32_t)(a & 0x1F) << 6 |
+               (int32_t)(b & 0x3F);
     } else if ((a & 0xF0) == 0xE0) {
         if ((i + 1) >= buf.len) goto exit;
         uint8_t b = buf.bytes[i++],
                 c = buf.bytes[i++];
         if ((b & 0xC0) != 0x80) goto exit;
         if ((c & 0xC0) != 0x80) goto exit;
-        res[0] = janet_wrap_integer((int32_t)(a & 0x0F) << 12 |
-                                    (int32_t)(b & 0x3F) <<  6 |
-                                    (int32_t)(c & 0x3F));
+        rune = (int32_t)(a & 0x0F) << 12 |
+               (int32_t)(b & 0x3F) <<  6 |
+               (int32_t)(c & 0x3F);
     } else if ((a & 0xF8) == 0xF0) {
         if ((i + 2) >= buf.len) goto exit;
         uint8_t b = buf.bytes[i++],
@@ -59,17 +60,17 @@ static JanetTuple decode_rune(JanetByteView buf, int32_t start) {
         if ((b & 0xC0) != 0x80) goto exit;
         if ((c & 0xC0) != 0x80) goto exit;
         if ((d & 0xC0) != 0x80) goto exit;
-        res[0] = janet_wrap_integer((int32_t)(a & 0x07) << 18 |
-                                    (int32_t)(b & 0x3F) << 12 |
-                                    (int32_t)(c & 0x3F) <<  6 |
-                                    (int32_t)(d & 0x3F));
+        rune = (int32_t)(a & 0x07) << 18 |
+               (int32_t)(b & 0x3F) << 12 |
+               (int32_t)(c & 0x3F) <<  6 |
+               (int32_t)(d & 0x3F);
     } else {
         goto exit;
     }
 
-    res[1] = janet_wrap_integer(i - start);
+    *start = i;
 exit:
-    return janet_tuple_n(&res[0], 2);
+    return rune;
 }
 
 JANET_FN(cfun_utf8_decode_rune,
@@ -84,7 +85,12 @@ JANET_FN(cfun_utf8_decode_rune,
         start = 0;
     }
 
-    return janet_wrap_tuple(decode_rune(buf, start));
+    int32_t i = start;
+    int32_t rune = decode_rune(buf, &i);
+    Janet res[2] = {
+        rune == -1 ? janet_wrap_nil() : janet_wrap_integer(rune),
+        janet_wrap_integer(i - start) };
+    return janet_wrap_tuple(janet_tuple_n(&res[0], 2));
 }
 
 JANET_FN(cfun_utf8_encode_rune,
@@ -143,13 +149,10 @@ JANET_FN(cfun_utf8_is_valid,
     JanetByteView buf = janet_getbytes(argv, 0);
     uint32_t i = 0;
     while (i < buf.len) {
-        JanetTuple res = decode_rune(buf, i);
-        if (janet_checktype(res[0], JANET_NIL))
-            return janet_wrap_boolean(0);
-        i += janet_unwrap_integer(res[1]);
+        if (decode_rune(buf, &i) == -1)
+            return janet_wrap_false();
     }
-
-    return janet_wrap_boolean(1);
+    return janet_wrap_true();
 }
 
 JANET_MODULE_ENTRY(JanetTable *env) {

--- a/test/suite-utf8.janet
+++ b/test/suite-utf8.janet
@@ -15,11 +15,11 @@
   (assert (= [dec (length enc)] (utf8/decode-rune enc))
           (string/format "utf8: decode (U+%X)" dec)))
 
-(each inv
-  ["\x81" # stray continuation
-   "\xf0\x90\x8a" "\xf0\x90\x8a" "\xf0\x90" "\xf0" # truncated forward
-   "\x90\x8a\x80" "\x8a\x80" "\x80" # truncated backward
-   "\xfe" "\xff"] # invalid
+(def invalid ["\x81" # stray continuation
+              "\xf0\x90\x8a" "\xf0\x90\x8a" "\xf0\x90" "\xf0" # truncated forward
+              "\x90\x8a\x80" "\x8a\x80" "\x80" # truncated backward
+              "\xfe" "\xff"])
+(each inv invalid
   (assert (= [nil 0] (utf8/decode-rune inv))
           (string/format "utf8: decode invalid (%q)" inv)))
 
@@ -81,5 +81,20 @@
           "utf8: encode reuse buffer")
   (assert (deep= @"aá" b)
           "utf8: encode reuse buffer (encoding result)"))
+
+###
+### utf8/is-valid?
+###
+(each inv invalid
+  (assert (false? (utf8/is-valid? inv))
+          (string/format "utf8: is-valid? failed on invalid seqeuence alone (%q)" inv))
+  (assert (false? (utf8/is-valid? (string inv "bar")))
+          (string/format "utf8: is-valid? failed on invalid sequence at start (%q)" inv))
+  (assert (false? (utf8/is-valid? (string "foo" inv)))
+          (string/format "utf8: is-valid? failed on invalid sequence at end (%q)" inv))
+  (assert (false? (utf8/is-valid? (string "foo" inv "bar")))
+          (string/format "utf8: is-valid? failed on invalid sequence in the middle (%q)" inv)))
+(assert  (true?  (utf8/is-valid? "hello")) "utf8: is-valid? on ascii")
+(assert  (true?  (utf8/is-valid? "안녕")) "utf8: is-valid? on valid non-ascii")
 
 (end-suite)

--- a/test/suite-utf8.janet
+++ b/test/suite-utf8.janet
@@ -94,7 +94,7 @@
           (string/format "utf8: is-valid? failed on invalid sequence at end (%q)" inv))
   (assert (false? (utf8/is-valid? (string "foo" inv "bar")))
           (string/format "utf8: is-valid? failed on invalid sequence in the middle (%q)" inv)))
-(assert  (true?  (utf8/is-valid? "hello")) "utf8: is-valid? on ascii")
-(assert  (true?  (utf8/is-valid? "안녕")) "utf8: is-valid? on valid non-ascii")
+(assert (true? (utf8/is-valid? "hello")) "utf8: is-valid? on ascii")
+(assert (true? (utf8/is-valid? "안녕")) "utf8: is-valid? on valid non-ascii")
 
 (end-suite)


### PR DESCRIPTION
Hi, I'm new to Janet and liking it very much so far!

I need to check if a string contains valid UTF-8.
I looked around but couldn't find anything. So here's my attempt.

Nothing too clever here, I'm just exposing the bulk of `decode-rune` as a helper function, and looping over the buffer.